### PR TITLE
fix(ci): trigger NuGet publish on 'released' event, not just 'published'

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -2,7 +2,7 @@ name: Publish to NuGet
 
 on:
   release:
-    types: [published]
+    types: [released, published]  # 'released' for direct publish, 'published' for draft->published
 
 permissions:
   contents: write


### PR DESCRIPTION
The publish-nuget workflow was only listening for the 'published' event, which only fires when converting a draft to published. When create-release creates a non-draft release directly, GitHub fires the 'released' event.

This change makes the workflow trigger on both:
- 'released': when a release is published directly (most common case)
- 'published': when a draft is converted to published (edge case)

This ensures automatic publishing works for all release creation scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)