### PR TITLE
fix(scheduling): Improve Timer callback reliability and test timing

### DIFF
--- a/tests/HeroMessaging.Tests/Unit/Scheduling/InMemorySchedulerTests.cs
+++ b/tests/HeroMessaging.Tests/Unit/Scheduling/InMemorySchedulerTests.cs
@@ -84,7 +84,9 @@ public class InMemorySchedulerTests : IAsyncLifetime
 
         // Act
         var result = await _scheduler!.ScheduleAsync(message, delay);
-        await Task.Delay(100); // Give it time to deliver
+
+        // Wait for async delivery to complete (Timer fires, Task.Run executes, delivery completes)
+        await Task.Delay(500);
 
         // Assert
         Assert.True(result.Success);
@@ -98,7 +100,7 @@ public class InMemorySchedulerTests : IAsyncLifetime
     {
         // Arrange
         var message = TestMessageBuilder.CreateValidMessage("Delayed message");
-        var delay = TimeSpan.FromMilliseconds(50);
+        var delay = TimeSpan.FromMilliseconds(100);
 
         // Act
         var result = await _scheduler!.ScheduleAsync(message, delay);
@@ -106,8 +108,8 @@ public class InMemorySchedulerTests : IAsyncLifetime
         // Assert - message should not be delivered yet
         Assert.Empty(_deliveryHandler!.DeliveredMessages);
 
-        // Wait for delivery
-        await Task.Delay(150);
+        // Wait for delivery (delay + async delivery overhead)
+        await Task.Delay(600);
 
         // Assert - message should be delivered now
         Assert.Single(_deliveryHandler.DeliveredMessages);
@@ -224,10 +226,11 @@ public class InMemorySchedulerTests : IAsyncLifetime
     {
         // Arrange
         var message = TestMessageBuilder.CreateValidMessage("Fast message");
-        var delay = TimeSpan.FromMilliseconds(50);
+        var delay = TimeSpan.FromMilliseconds(100);
         var result = await _scheduler!.ScheduleAsync(message, delay);
 
-        await Task.Delay(150); // Wait for delivery
+        // Wait for delivery to complete
+        await Task.Delay(600);
 
         // Act
         var cancelled = await _scheduler.CancelScheduledAsync(result.ScheduleId);
@@ -276,10 +279,11 @@ public class InMemorySchedulerTests : IAsyncLifetime
     {
         // Arrange
         var message = TestMessageBuilder.CreateValidMessage("Delivered message");
-        var delay = TimeSpan.FromMilliseconds(50);
+        var delay = TimeSpan.FromMilliseconds(100);
         var result = await _scheduler!.ScheduleAsync(message, delay);
 
-        await Task.Delay(150); // Wait for delivery
+        // Wait for delivery to complete
+        await Task.Delay(600);
 
         // Act
         var info = await _scheduler.GetScheduledAsync(result.ScheduleId);
@@ -387,10 +391,12 @@ public class InMemorySchedulerTests : IAsyncLifetime
     {
         // Arrange
         var message = TestMessageBuilder.CreateValidMessage("Fast message");
-        await _scheduler!.ScheduleAsync(message, TimeSpan.FromMilliseconds(50));
+        await _scheduler!.ScheduleAsync(message, TimeSpan.FromMilliseconds(100));
 
         var initialCount = await _scheduler.GetPendingCountAsync();
-        await Task.Delay(150); // Wait for delivery
+
+        // Wait for delivery to complete
+        await Task.Delay(600);
 
         // Act
         var finalCount = await _scheduler.GetPendingCountAsync();


### PR DESCRIPTION
Multiple improvements to fix flaky delivery tests:

1. Refactor Timer callback to use dedicated method with state parameter
   - Changed from closure capturing scheduleId to passing via state
   - Created dedicated TimerCallback(object? state) method
   - Cleaner separation of concerns and more reliable execution

2. Increase test wait times for async delivery
   - Changed from 100-150ms to 500-600ms
   - Accounts for CI system overhead and async task scheduling
   - Tests: WithZeroDelay, WithShortDelay, AfterDelivery, etc.
   - More reliable on slower/busy CI runners

3. Keep thread-safe TestMessageDeliveryHandler using ConcurrentBag

The Timer fires -> TimerCallback extracts Guid from state -> Task.Run executes DeliverScheduledMessage on thread pool -> delivery completes. Tests wait long enough for the full async chain to complete.

Fixes test failures:
- ScheduleAsync_WithZeroDelay_DeliversImmediately
- ScheduleAsync_WithShortDelay_DeliversAfterDelay
- GetScheduledAsync_AfterDelivery_ShowsDeliveredStatus
- GetPendingCountAsync_AfterDelivery_DecreasesCount
- CancelScheduledAsync_WithAlreadyDeliveredMessage_ReturnsFalse