### PR TITLE
Add HeroMessaging.Security project with HMAC-SHA256 signing and AES-G…

### DIFF
--- a/HeroMessaging.sln
+++ b/HeroMessaging.sln
@@ -41,6 +41,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeroMessaging.Serialization
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeroMessaging.Observability.HealthChecks.Tests", "tests\HeroMessaging.Observability.HealthChecks.Tests\HeroMessaging.Observability.HealthChecks.Tests.csproj", "{20B95953-2136-47D1-BADA-6774B14CE8D8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeroMessaging.Security", "src\HeroMessaging.Security\HeroMessaging.Security.csproj", "{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeroMessaging.Security.Tests", "tests\HeroMessaging.Security.Tests\HeroMessaging.Security.Tests.csproj", "{87946634-4A83-4908-B2E7-817167512531}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +259,30 @@ Global
 		{20B95953-2136-47D1-BADA-6774B14CE8D8}.Release|x64.Build.0 = Release|Any CPU
 		{20B95953-2136-47D1-BADA-6774B14CE8D8}.Release|x86.ActiveCfg = Release|Any CPU
 		{20B95953-2136-47D1-BADA-6774B14CE8D8}.Release|x86.Build.0 = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|x64.Build.0 = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Debug|x86.Build.0 = Debug|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|x64.ActiveCfg = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|x64.Build.0 = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|x86.ActiveCfg = Release|Any CPU
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719}.Release|x86.Build.0 = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|x64.Build.0 = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Debug|x86.Build.0 = Debug|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|x64.ActiveCfg = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|x64.Build.0 = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|x86.ActiveCfg = Release|Any CPU
+		{87946634-4A83-4908-B2E7-817167512531}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -277,5 +305,7 @@ Global
 		{05909816-E6FF-404E-BBD0-0390F2D1226A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{B90A9FF9-CA24-4B7D-BF53-0112E4A86841} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{20B95953-2136-47D1-BADA-6774B14CE8D8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{4C2B60BD-4E7C-4773-AAA6-DDBCB2510719} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{87946634-4A83-4908-B2E7-817167512531} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/HeroMessaging.Abstractions/HeroMessaging.Abstractions.csproj
+++ b/src/HeroMessaging.Abstractions/HeroMessaging.Abstractions.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="PolySharp" />
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Security.Claims" />
   </ItemGroup>
   
   <ItemGroup>
@@ -38,6 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Update="System.Collections.Immutable" Version="9.0.9" />
+    <PackageReference Update="System.Security.Claims" Version="4.3.0" />
   </ItemGroup>
   
 </Project>

--- a/src/HeroMessaging.Abstractions/Security/IAuthenticationProvider.cs
+++ b/src/HeroMessaging.Abstractions/Security/IAuthenticationProvider.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Provides authentication services for message senders
+/// </summary>
+public interface IAuthenticationProvider
+{
+    /// <summary>
+    /// Authenticates a message sender based on credentials or tokens
+    /// </summary>
+    /// <param name="credentials">The authentication credentials</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Authenticated principal if successful, null otherwise</returns>
+    Task<ClaimsPrincipal?> AuthenticateAsync(
+        AuthenticationCredentials credentials,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates an authentication token
+    /// </summary>
+    /// <param name="token">The token to validate</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Authenticated principal if token is valid, null otherwise</returns>
+    Task<ClaimsPrincipal?> ValidateTokenAsync(
+        string token,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the authentication scheme name
+    /// </summary>
+    string Scheme { get; }
+}
+
+/// <summary>
+/// Represents authentication credentials
+/// </summary>
+public sealed class AuthenticationCredentials
+{
+    /// <summary>
+    /// Authentication scheme (e.g., "Bearer", "ApiKey", "Basic")
+    /// </summary>
+    public string Scheme { get; }
+
+    /// <summary>
+    /// The credential value (token, key, password, etc.)
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Additional parameters for authentication
+    /// </summary>
+    public IDictionary<string, string> Parameters { get; }
+
+    public AuthenticationCredentials(string scheme, string value)
+    {
+        Scheme = scheme ?? throw new ArgumentNullException(nameof(scheme));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+        Parameters = new Dictionary<string, string>();
+    }
+
+    /// <summary>
+    /// Creates credentials from an authorization header value
+    /// </summary>
+    public static AuthenticationCredentials FromAuthorizationHeader(string headerValue)
+    {
+        if (string.IsNullOrWhiteSpace(headerValue))
+            throw new ArgumentException("Header value cannot be empty", nameof(headerValue));
+
+        var parts = headerValue.Split(new[] { ' ' }, 2);
+        if (parts.Length != 2)
+            throw new ArgumentException("Invalid authorization header format", nameof(headerValue));
+
+        return new AuthenticationCredentials(parts[0], parts[1]);
+    }
+}
+
+/// <summary>
+/// Result of an authentication operation
+/// </summary>
+public sealed class AuthenticationResult
+{
+    /// <summary>
+    /// Whether authentication succeeded
+    /// </summary>
+    public bool Succeeded { get; }
+
+    /// <summary>
+    /// The authenticated principal if successful
+    /// </summary>
+    public ClaimsPrincipal? Principal { get; }
+
+    /// <summary>
+    /// Error message if authentication failed
+    /// </summary>
+    public string? ErrorMessage { get; }
+
+    private AuthenticationResult(bool succeeded, ClaimsPrincipal? principal, string? errorMessage)
+    {
+        Succeeded = succeeded;
+        Principal = principal;
+        ErrorMessage = errorMessage;
+    }
+
+    public static AuthenticationResult Success(ClaimsPrincipal principal)
+        => new(true, principal, null);
+
+    public static AuthenticationResult Failure(string errorMessage)
+        => new(false, null, errorMessage);
+}

--- a/src/HeroMessaging.Abstractions/Security/IAuthorizationProvider.cs
+++ b/src/HeroMessaging.Abstractions/Security/IAuthorizationProvider.cs
@@ -1,0 +1,87 @@
+using System.Security.Claims;
+
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Provides authorization services for message handling
+/// </summary>
+public interface IAuthorizationProvider
+{
+    /// <summary>
+    /// Authorizes a message operation
+    /// </summary>
+    /// <param name="principal">The authenticated principal</param>
+    /// <param name="messageType">The type of message being processed</param>
+    /// <param name="operation">The operation being performed (Send, Receive, Handle)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Authorization result</returns>
+    Task<AuthorizationResult> AuthorizeAsync(
+        ClaimsPrincipal principal,
+        string messageType,
+        string operation,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a principal has a specific permission
+    /// </summary>
+    /// <param name="principal">The authenticated principal</param>
+    /// <param name="permission">The permission to check</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if authorized, false otherwise</returns>
+    Task<bool> HasPermissionAsync(
+        ClaimsPrincipal principal,
+        string permission,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of an authorization check
+/// </summary>
+public sealed class AuthorizationResult
+{
+    /// <summary>
+    /// Whether authorization succeeded
+    /// </summary>
+    public bool Succeeded { get; }
+
+    /// <summary>
+    /// Error message if authorization failed
+    /// </summary>
+    public string? ErrorMessage { get; }
+
+    /// <summary>
+    /// Reason for failure (e.g., "InsufficientPermissions", "ResourceNotFound")
+    /// </summary>
+    public string? FailureReason { get; }
+
+    private AuthorizationResult(bool succeeded, string? errorMessage, string? failureReason)
+    {
+        Succeeded = succeeded;
+        ErrorMessage = errorMessage;
+        FailureReason = failureReason;
+    }
+
+    public static AuthorizationResult Success()
+        => new(true, null, null);
+
+    public static AuthorizationResult Failure(string errorMessage, string? failureReason = null)
+        => new(false, errorMessage, failureReason);
+
+    public static AuthorizationResult InsufficientPermissions(string requiredPermission)
+        => new(false, $"Insufficient permissions. Required: {requiredPermission}", "InsufficientPermissions");
+
+    public static AuthorizationResult Forbidden(string message)
+        => new(false, message, "Forbidden");
+}
+
+/// <summary>
+/// Standard message operations for authorization
+/// </summary>
+public static class MessageOperations
+{
+    public const string Send = "Send";
+    public const string Receive = "Receive";
+    public const string Handle = "Handle";
+    public const string Publish = "Publish";
+    public const string Subscribe = "Subscribe";
+}

--- a/src/HeroMessaging.Abstractions/Security/IMessageEncryptor.cs
+++ b/src/HeroMessaging.Abstractions/Security/IMessageEncryptor.cs
@@ -1,0 +1,81 @@
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Provides encryption and decryption capabilities for message payloads
+/// </summary>
+public interface IMessageEncryptor
+{
+    /// <summary>
+    /// Encrypts the message payload
+    /// </summary>
+    /// <param name="plaintext">The plaintext data to encrypt</param>
+    /// <param name="context">Security context for encryption metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Encrypted data with initialization vector and authentication tag</returns>
+    Task<EncryptedData> EncryptAsync(
+        byte[] plaintext,
+        SecurityContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Decrypts the message payload
+    /// </summary>
+    /// <param name="encryptedData">The encrypted data to decrypt</param>
+    /// <param name="context">Security context for decryption metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Decrypted plaintext data</returns>
+    Task<byte[]> DecryptAsync(
+        EncryptedData encryptedData,
+        SecurityContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the encryption algorithm identifier
+    /// </summary>
+    string Algorithm { get; }
+}
+
+/// <summary>
+/// Represents encrypted data with metadata
+/// </summary>
+public sealed class EncryptedData
+{
+    /// <summary>
+    /// The encrypted ciphertext
+    /// </summary>
+    public byte[] Ciphertext { get; }
+
+    /// <summary>
+    /// Initialization vector used for encryption
+    /// </summary>
+    public byte[] InitializationVector { get; }
+
+    /// <summary>
+    /// Authentication tag for authenticated encryption (e.g., GCM mode)
+    /// </summary>
+    public byte[]? AuthenticationTag { get; }
+
+    /// <summary>
+    /// Key identifier for key rotation support
+    /// </summary>
+    public string? KeyId { get; }
+
+    /// <summary>
+    /// Algorithm used for encryption
+    /// </summary>
+    public string Algorithm { get; }
+
+    public EncryptedData(
+        byte[] ciphertext,
+        byte[] initializationVector,
+        string algorithm,
+        byte[]? authenticationTag = null,
+        string? keyId = null)
+    {
+        Ciphertext = ciphertext ?? throw new ArgumentNullException(nameof(ciphertext));
+        InitializationVector = initializationVector ?? throw new ArgumentNullException(nameof(initializationVector));
+        Algorithm = algorithm ?? throw new ArgumentNullException(nameof(algorithm));
+        AuthenticationTag = authenticationTag;
+        KeyId = keyId;
+    }
+}

--- a/src/HeroMessaging.Abstractions/Security/IMessageSigner.cs
+++ b/src/HeroMessaging.Abstractions/Security/IMessageSigner.cs
@@ -1,0 +1,76 @@
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Provides message signing and verification for integrity and authenticity
+/// </summary>
+public interface IMessageSigner
+{
+    /// <summary>
+    /// Signs the message data
+    /// </summary>
+    /// <param name="data">The data to sign</param>
+    /// <param name="context">Security context for signing metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Digital signature</returns>
+    Task<MessageSignature> SignAsync(
+        byte[] data,
+        SecurityContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Verifies the message signature
+    /// </summary>
+    /// <param name="data">The data that was signed</param>
+    /// <param name="signature">The signature to verify</param>
+    /// <param name="context">Security context for verification metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if signature is valid, false otherwise</returns>
+    Task<bool> VerifyAsync(
+        byte[] data,
+        MessageSignature signature,
+        SecurityContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the signing algorithm identifier
+    /// </summary>
+    string Algorithm { get; }
+}
+
+/// <summary>
+/// Represents a message signature with metadata
+/// </summary>
+public sealed class MessageSignature
+{
+    /// <summary>
+    /// The signature bytes
+    /// </summary>
+    public byte[] SignatureBytes { get; }
+
+    /// <summary>
+    /// Algorithm used for signing
+    /// </summary>
+    public string Algorithm { get; }
+
+    /// <summary>
+    /// Key identifier for key rotation support
+    /// </summary>
+    public string? KeyId { get; }
+
+    /// <summary>
+    /// Timestamp when signature was created
+    /// </summary>
+    public DateTimeOffset Timestamp { get; }
+
+    public MessageSignature(
+        byte[] signatureBytes,
+        string algorithm,
+        string? keyId = null,
+        DateTimeOffset? timestamp = null)
+    {
+        SignatureBytes = signatureBytes ?? throw new ArgumentNullException(nameof(signatureBytes));
+        Algorithm = algorithm ?? throw new ArgumentNullException(nameof(algorithm));
+        KeyId = keyId;
+        Timestamp = timestamp ?? DateTimeOffset.UtcNow;
+    }
+}

--- a/src/HeroMessaging.Abstractions/Security/SecurityContext.cs
+++ b/src/HeroMessaging.Abstractions/Security/SecurityContext.cs
@@ -1,0 +1,75 @@
+using System.Security.Claims;
+
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Represents the security context for message operations
+/// </summary>
+public sealed class SecurityContext
+{
+    /// <summary>
+    /// The authenticated principal (user/service identity)
+    /// </summary>
+    public ClaimsPrincipal? Principal { get; set; }
+
+    /// <summary>
+    /// Message identifier for audit trail
+    /// </summary>
+    public string? MessageId { get; set; }
+
+    /// <summary>
+    /// Message type for authorization decisions
+    /// </summary>
+    public string? MessageType { get; set; }
+
+    /// <summary>
+    /// Correlation identifier for distributed tracing
+    /// </summary>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Additional metadata for security operations
+    /// </summary>
+    public IDictionary<string, object> Metadata { get; }
+
+    /// <summary>
+    /// Timestamp when context was created
+    /// </summary>
+    public DateTimeOffset Timestamp { get; }
+
+    public SecurityContext()
+    {
+        Metadata = new Dictionary<string, object>();
+        Timestamp = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Gets whether the context has an authenticated principal
+    /// </summary>
+    public bool IsAuthenticated => Principal?.Identity?.IsAuthenticated ?? false;
+
+    /// <summary>
+    /// Gets the principal's name if authenticated
+    /// </summary>
+    public string? PrincipalName => Principal?.Identity?.Name;
+
+    /// <summary>
+    /// Checks if the principal has a specific claim
+    /// </summary>
+    public bool HasClaim(string claimType, string? claimValue = null)
+    {
+        if (Principal == null) return false;
+
+        return claimValue == null
+            ? Principal.HasClaim(c => c.Type == claimType)
+            : Principal.HasClaim(claimType, claimValue);
+    }
+
+    /// <summary>
+    /// Gets all claims of a specific type
+    /// </summary>
+    public IEnumerable<Claim> GetClaims(string claimType)
+    {
+        return Principal?.FindAll(claimType) ?? Enumerable.Empty<Claim>();
+    }
+}

--- a/src/HeroMessaging.Abstractions/Security/SecurityException.cs
+++ b/src/HeroMessaging.Abstractions/Security/SecurityException.cs
@@ -1,0 +1,74 @@
+namespace HeroMessaging.Abstractions.Security;
+
+/// <summary>
+/// Base exception for security-related errors
+/// </summary>
+public class SecurityException : Exception
+{
+    public SecurityException(string message) : base(message)
+    {
+    }
+
+    public SecurityException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when encryption or decryption fails
+/// </summary>
+public class EncryptionException : SecurityException
+{
+    public EncryptionException(string message) : base(message)
+    {
+    }
+
+    public EncryptionException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when signature verification fails
+/// </summary>
+public class SignatureVerificationException : SecurityException
+{
+    public SignatureVerificationException(string message) : base(message)
+    {
+    }
+
+    public SignatureVerificationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when authentication fails
+/// </summary>
+public class AuthenticationException : SecurityException
+{
+    public AuthenticationException(string message) : base(message)
+    {
+    }
+
+    public AuthenticationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when authorization fails
+/// </summary>
+public class AuthorizationException : SecurityException
+{
+    public string? RequiredPermission { get; }
+
+    public AuthorizationException(string message, string? requiredPermission = null) : base(message)
+    {
+        RequiredPermission = requiredPermission;
+    }
+
+    public AuthorizationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/HeroMessaging.Security/Authentication/ClaimsAuthenticationProvider.cs
+++ b/src/HeroMessaging.Security/Authentication/ClaimsAuthenticationProvider.cs
@@ -1,0 +1,90 @@
+using System.Security.Claims;
+using HeroMessaging.Abstractions.Security;
+
+namespace HeroMessaging.Security.Authentication;
+
+/// <summary>
+/// Provides claims-based authentication for messages
+/// </summary>
+public sealed class ClaimsAuthenticationProvider : IAuthenticationProvider
+{
+    private readonly Dictionary<string, ClaimsPrincipal> _apiKeys;
+    private readonly string _scheme;
+
+    public string Scheme => _scheme;
+
+    /// <summary>
+    /// Creates a new claims authentication provider
+    /// </summary>
+    /// <param name="scheme">Authentication scheme name (e.g., "ApiKey", "Bearer")</param>
+    public ClaimsAuthenticationProvider(string scheme = "ApiKey")
+    {
+        _scheme = scheme ?? throw new ArgumentNullException(nameof(scheme));
+        _apiKeys = new Dictionary<string, ClaimsPrincipal>(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Registers an API key with associated claims
+    /// </summary>
+    public void RegisterApiKey(string apiKey, ClaimsPrincipal principal)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new ArgumentException("API key cannot be empty", nameof(apiKey));
+
+        if (principal == null)
+            throw new ArgumentNullException(nameof(principal));
+
+        _apiKeys[apiKey] = principal;
+    }
+
+    /// <summary>
+    /// Registers an API key with a simple identity
+    /// </summary>
+    public void RegisterApiKey(string apiKey, string name, params Claim[] claims)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new ArgumentException("API key cannot be empty", nameof(apiKey));
+
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be empty", nameof(name));
+
+        var identity = new ClaimsIdentity(claims, _scheme, ClaimTypes.Name, ClaimTypes.Role);
+        identity.AddClaim(new Claim(ClaimTypes.Name, name));
+
+        var principal = new ClaimsPrincipal(identity);
+        _apiKeys[apiKey] = principal;
+    }
+
+    public Task<ClaimsPrincipal?> AuthenticateAsync(
+        AuthenticationCredentials credentials,
+        CancellationToken cancellationToken = default)
+    {
+        if (credentials == null)
+            throw new ArgumentNullException(nameof(credentials));
+
+        if (credentials.Scheme != _scheme)
+            return Task.FromResult<ClaimsPrincipal?>(null);
+
+        if (_apiKeys.TryGetValue(credentials.Value, out var principal))
+        {
+            return Task.FromResult<ClaimsPrincipal?>(principal);
+        }
+
+        return Task.FromResult<ClaimsPrincipal?>(null);
+    }
+
+    public Task<ClaimsPrincipal?> ValidateTokenAsync(
+        string token,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return Task.FromResult<ClaimsPrincipal?>(null);
+
+        if (_apiKeys.TryGetValue(token, out var principal))
+        {
+            return Task.FromResult<ClaimsPrincipal?>(principal);
+        }
+
+        return Task.FromResult<ClaimsPrincipal?>(null);
+    }
+}

--- a/src/HeroMessaging.Security/Authorization/PolicyAuthorizationProvider.cs
+++ b/src/HeroMessaging.Security/Authorization/PolicyAuthorizationProvider.cs
@@ -1,0 +1,319 @@
+using System.Security.Claims;
+using HeroMessaging.Abstractions.Security;
+
+namespace HeroMessaging.Security.Authorization;
+
+/// <summary>
+/// Provides policy-based authorization for message operations
+/// </summary>
+public sealed class PolicyAuthorizationProvider : IAuthorizationProvider
+{
+    private readonly Dictionary<string, AuthorizationPolicy> _policies;
+    private readonly bool _requireAuthenticatedUser;
+
+    /// <summary>
+    /// Creates a new policy-based authorization provider
+    /// </summary>
+    /// <param name="requireAuthenticatedUser">Whether to require authenticated users for all operations</param>
+    public PolicyAuthorizationProvider(bool requireAuthenticatedUser = true)
+    {
+        _requireAuthenticatedUser = requireAuthenticatedUser;
+        _policies = new Dictionary<string, AuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Registers an authorization policy
+    /// </summary>
+    public void AddPolicy(string name, AuthorizationPolicy policy)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Policy name cannot be empty", nameof(name));
+
+        if (policy == null)
+            throw new ArgumentNullException(nameof(policy));
+
+        _policies[name] = policy;
+    }
+
+    /// <summary>
+    /// Registers a role-based policy
+    /// </summary>
+    public void RequireRole(string messageType, string operation, params string[] roles)
+    {
+        var policyName = GetPolicyName(messageType, operation);
+        var policy = new AuthorizationPolicy(policyName)
+            .RequireAuthenticatedUser()
+            .RequireRole(roles);
+
+        _policies[policyName] = policy;
+    }
+
+    /// <summary>
+    /// Registers a claim-based policy
+    /// </summary>
+    public void RequireClaim(string messageType, string operation, string claimType, params string[] allowedValues)
+    {
+        var policyName = GetPolicyName(messageType, operation);
+        var policy = new AuthorizationPolicy(policyName)
+            .RequireAuthenticatedUser()
+            .RequireClaim(claimType, allowedValues);
+
+        _policies[policyName] = policy;
+    }
+
+    /// <summary>
+    /// Allows anonymous access for a specific message type and operation
+    /// </summary>
+    public void AllowAnonymous(string messageType, string operation)
+    {
+        var policyName = GetPolicyName(messageType, operation);
+        var policy = new AuthorizationPolicy(policyName)
+            .AllowAnonymous();
+
+        _policies[policyName] = policy;
+    }
+
+    public Task<AuthorizationResult> AuthorizeAsync(
+        ClaimsPrincipal principal,
+        string messageType,
+        string operation,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(messageType))
+            throw new ArgumentException("Message type cannot be empty", nameof(messageType));
+
+        if (string.IsNullOrWhiteSpace(operation))
+            throw new ArgumentException("Operation cannot be empty", nameof(operation));
+
+        // Check for specific policy
+        var policyName = GetPolicyName(messageType, operation);
+        if (_policies.TryGetValue(policyName, out var policy))
+        {
+            return Task.FromResult(policy.Evaluate(principal));
+        }
+
+        // Check for wildcard message type policy
+        var wildcardPolicyName = GetPolicyName("*", operation);
+        if (_policies.TryGetValue(wildcardPolicyName, out var wildcardPolicy))
+        {
+            return Task.FromResult(wildcardPolicy.Evaluate(principal));
+        }
+
+        // Default behavior: require authenticated user if configured
+        if (_requireAuthenticatedUser)
+        {
+            if (principal?.Identity?.IsAuthenticated != true)
+            {
+                return Task.FromResult(AuthorizationResult.Failure(
+                    "Authentication required for message operation",
+                    "Unauthenticated"));
+            }
+        }
+
+        return Task.FromResult(AuthorizationResult.Success());
+    }
+
+    public Task<bool> HasPermissionAsync(
+        ClaimsPrincipal principal,
+        string permission,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(permission))
+            throw new ArgumentException("Permission cannot be empty", nameof(permission));
+
+        if (principal == null)
+            return Task.FromResult(false);
+
+        // Check for permission claim
+        var hasPermission = principal.HasClaim(c =>
+            c.Type == "permission" &&
+            c.Value.Equals(permission, StringComparison.OrdinalIgnoreCase));
+
+        return Task.FromResult(hasPermission);
+    }
+
+    private static string GetPolicyName(string messageType, string operation)
+    {
+        return $"{messageType}:{operation}";
+    }
+}
+
+/// <summary>
+/// Represents an authorization policy with requirements
+/// </summary>
+public sealed class AuthorizationPolicy
+{
+    private readonly string _name;
+    private bool _requireAuthentication = true;
+    private bool _allowAnonymous;
+    private readonly HashSet<string> _requiredRoles;
+    private readonly Dictionary<string, HashSet<string>> _requiredClaims;
+    private readonly List<Func<ClaimsPrincipal, bool>> _customRequirements;
+
+    public string Name => _name;
+
+    public AuthorizationPolicy(string name)
+    {
+        _name = name ?? throw new ArgumentNullException(nameof(name));
+        _requiredRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _requiredClaims = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        _customRequirements = new List<Func<ClaimsPrincipal, bool>>();
+    }
+
+    /// <summary>
+    /// Requires an authenticated user
+    /// </summary>
+    public AuthorizationPolicy RequireAuthenticatedUser()
+    {
+        _requireAuthentication = true;
+        _allowAnonymous = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Allows anonymous access
+    /// </summary>
+    public AuthorizationPolicy AllowAnonymous()
+    {
+        _allowAnonymous = true;
+        _requireAuthentication = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Requires the user to be in one of the specified roles
+    /// </summary>
+    public AuthorizationPolicy RequireRole(params string[] roles)
+    {
+        if (roles == null || roles.Length == 0)
+            throw new ArgumentException("At least one role is required", nameof(roles));
+
+        foreach (var role in roles)
+        {
+            if (!string.IsNullOrWhiteSpace(role))
+                _requiredRoles.Add(role);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Requires the user to have a specific claim
+    /// </summary>
+    public AuthorizationPolicy RequireClaim(string claimType, params string[] allowedValues)
+    {
+        if (string.IsNullOrWhiteSpace(claimType))
+            throw new ArgumentException("Claim type cannot be empty", nameof(claimType));
+
+        if (!_requiredClaims.ContainsKey(claimType))
+        {
+            _requiredClaims[claimType] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (allowedValues != null && allowedValues.Length > 0)
+        {
+            foreach (var value in allowedValues)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    _requiredClaims[claimType].Add(value);
+            }
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom authorization requirement
+    /// </summary>
+    public AuthorizationPolicy RequireAssertion(Func<ClaimsPrincipal, bool> requirement)
+    {
+        if (requirement == null)
+            throw new ArgumentNullException(nameof(requirement));
+
+        _customRequirements.Add(requirement);
+        return this;
+    }
+
+    /// <summary>
+    /// Evaluates the policy against a principal
+    /// </summary>
+    public AuthorizationResult Evaluate(ClaimsPrincipal principal)
+    {
+        // Allow anonymous if configured
+        if (_allowAnonymous)
+            return AuthorizationResult.Success();
+
+        // Check authentication requirement
+        if (_requireAuthentication)
+        {
+            if (principal?.Identity?.IsAuthenticated != true)
+            {
+                return AuthorizationResult.Failure(
+                    $"Policy '{_name}' requires an authenticated user",
+                    "Unauthenticated");
+            }
+        }
+
+        // Check role requirements
+        if (_requiredRoles.Count > 0)
+        {
+            var hasRequiredRole = _requiredRoles.Any(role => principal.IsInRole(role));
+            if (!hasRequiredRole)
+            {
+                return AuthorizationResult.InsufficientPermissions(
+                    $"Required roles: {string.Join(", ", _requiredRoles)}");
+            }
+        }
+
+        // Check claim requirements
+        foreach (var claimRequirement in _requiredClaims)
+        {
+            var claimType = claimRequirement.Key;
+            var allowedValues = claimRequirement.Value;
+
+            if (allowedValues.Count == 0)
+            {
+                // Just require the claim exists
+                if (!principal.HasClaim(c => c.Type == claimType))
+                {
+                    return AuthorizationResult.InsufficientPermissions($"Required claim: {claimType}");
+                }
+            }
+            else
+            {
+                // Require specific claim values
+                var hasValidClaim = principal.Claims.Any(c =>
+                    c.Type == claimType &&
+                    allowedValues.Contains(c.Value));
+
+                if (!hasValidClaim)
+                {
+                    return AuthorizationResult.InsufficientPermissions(
+                        $"Required claim: {claimType} with values: {string.Join(", ", allowedValues)}");
+                }
+            }
+        }
+
+        // Check custom requirements
+        foreach (var requirement in _customRequirements)
+        {
+            try
+            {
+                if (!requirement(principal))
+                {
+                    return AuthorizationResult.Failure(
+                        $"Custom authorization requirement failed for policy '{_name}'",
+                        "CustomRequirementFailed");
+                }
+            }
+            catch (Exception ex)
+            {
+                return AuthorizationResult.Failure(
+                    $"Custom authorization requirement threw exception: {ex.Message}",
+                    "CustomRequirementException");
+            }
+        }
+
+        return AuthorizationResult.Success();
+    }
+}

--- a/src/HeroMessaging.Security/Configuration/SecurityBuilderExtensions.cs
+++ b/src/HeroMessaging.Security/Configuration/SecurityBuilderExtensions.cs
@@ -1,0 +1,263 @@
+using HeroMessaging.Abstractions.Security;
+using HeroMessaging.Security.Authentication;
+using HeroMessaging.Security.Authorization;
+using HeroMessaging.Security.Encryption;
+using HeroMessaging.Security.Signing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HeroMessaging.Security.Configuration;
+
+/// <summary>
+/// Extension methods for configuring message security
+/// </summary>
+public static class SecurityBuilderExtensions
+{
+    /// <summary>
+    /// Adds AES-256-GCM encryption to the message pipeline
+    /// </summary>
+    public static IServiceCollection AddAesGcmEncryption(
+        this IServiceCollection services,
+        byte[] key,
+        string? keyId = null)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+
+        services.AddSingleton<IMessageEncryptor>(sp =>
+            new AesGcmMessageEncryptor(key, keyId));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds AES-256-GCM encryption with a randomly generated key
+    /// </summary>
+    public static IServiceCollection AddAesGcmEncryption(
+        this IServiceCollection services,
+        string? keyId = null)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        services.AddSingleton<IMessageEncryptor>(sp =>
+            AesGcmMessageEncryptor.CreateWithRandomKey(keyId));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds HMAC-SHA256 message signing
+    /// </summary>
+    public static IServiceCollection AddHmacSha256Signing(
+        this IServiceCollection services,
+        byte[] key,
+        string? keyId = null)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+
+        services.AddSingleton<IMessageSigner>(sp =>
+            new HmacSha256MessageSigner(key, keyId));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds HMAC-SHA256 signing with a randomly generated key
+    /// </summary>
+    public static IServiceCollection AddHmacSha256Signing(
+        this IServiceCollection services,
+        string? keyId = null)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        services.AddSingleton<IMessageSigner>(sp =>
+            HmacSha256MessageSigner.CreateWithRandomKey(keyId));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds claims-based authentication
+    /// </summary>
+    public static IServiceCollection AddClaimsAuthentication(
+        this IServiceCollection services,
+        string scheme = "ApiKey")
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        services.AddSingleton<IAuthenticationProvider>(sp =>
+            new ClaimsAuthenticationProvider(scheme));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds claims-based authentication with a configuration action
+    /// </summary>
+    public static IServiceCollection AddClaimsAuthentication(
+        this IServiceCollection services,
+        Action<ClaimsAuthenticationProvider> configure,
+        string scheme = "ApiKey")
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var provider = new ClaimsAuthenticationProvider(scheme);
+        configure(provider);
+
+        services.AddSingleton<IAuthenticationProvider>(provider);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds policy-based authorization
+    /// </summary>
+    public static IServiceCollection AddPolicyAuthorization(
+        this IServiceCollection services,
+        bool requireAuthenticatedUser = true)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        services.AddSingleton<IAuthorizationProvider>(sp =>
+            new PolicyAuthorizationProvider(requireAuthenticatedUser));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds policy-based authorization with a configuration action
+    /// </summary>
+    public static IServiceCollection AddPolicyAuthorization(
+        this IServiceCollection services,
+        Action<PolicyAuthorizationProvider> configure,
+        bool requireAuthenticatedUser = true)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var provider = new PolicyAuthorizationProvider(requireAuthenticatedUser);
+        configure(provider);
+
+        services.AddSingleton<IAuthorizationProvider>(provider);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds complete message security with encryption, signing, authentication, and authorization
+    /// </summary>
+    public static IServiceCollection AddMessageSecurity(
+        this IServiceCollection services,
+        Action<MessageSecurityBuilder>? configure = null)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        var builder = new MessageSecurityBuilder(services);
+        configure?.Invoke(builder);
+
+        return services;
+    }
+}
+
+/// <summary>
+/// Builder for configuring message security
+/// </summary>
+public sealed class MessageSecurityBuilder
+{
+    private readonly IServiceCollection _services;
+
+    public MessageSecurityBuilder(IServiceCollection services)
+    {
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+    }
+
+    /// <summary>
+    /// Adds AES-256-GCM encryption
+    /// </summary>
+    public MessageSecurityBuilder WithAesGcmEncryption(byte[] key, string? keyId = null)
+    {
+        _services.AddAesGcmEncryption(key, keyId);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds AES-256-GCM encryption with random key
+    /// </summary>
+    public MessageSecurityBuilder WithAesGcmEncryption(string? keyId = null)
+    {
+        _services.AddAesGcmEncryption(keyId);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds HMAC-SHA256 signing
+    /// </summary>
+    public MessageSecurityBuilder WithHmacSha256Signing(byte[] key, string? keyId = null)
+    {
+        _services.AddHmacSha256Signing(key, keyId);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds HMAC-SHA256 signing with random key
+    /// </summary>
+    public MessageSecurityBuilder WithHmacSha256Signing(string? keyId = null)
+    {
+        _services.AddHmacSha256Signing(keyId);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds claims-based authentication
+    /// </summary>
+    public MessageSecurityBuilder WithClaimsAuthentication(
+        Action<ClaimsAuthenticationProvider>? configure = null,
+        string scheme = "ApiKey")
+    {
+        if (configure != null)
+        {
+            _services.AddClaimsAuthentication(configure, scheme);
+        }
+        else
+        {
+            _services.AddClaimsAuthentication(scheme);
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Adds policy-based authorization
+    /// </summary>
+    public MessageSecurityBuilder WithPolicyAuthorization(
+        Action<PolicyAuthorizationProvider>? configure = null,
+        bool requireAuthenticatedUser = true)
+    {
+        if (configure != null)
+        {
+            _services.AddPolicyAuthorization(configure, requireAuthenticatedUser);
+        }
+        else
+        {
+            _services.AddPolicyAuthorization(requireAuthenticatedUser);
+        }
+        return this;
+    }
+}

--- a/src/HeroMessaging.Security/Encryption/AesGcmMessageEncryptor.cs
+++ b/src/HeroMessaging.Security/Encryption/AesGcmMessageEncryptor.cs
@@ -1,0 +1,159 @@
+using System.Security.Cryptography;
+using HeroMessaging.Abstractions.Security;
+
+namespace HeroMessaging.Security.Encryption;
+
+/// <summary>
+/// Provides AES-256-GCM authenticated encryption for messages
+/// </summary>
+public sealed class AesGcmMessageEncryptor : IMessageEncryptor
+{
+    private const int KeySize = 32; // 256 bits
+    private const int NonceSize = 12; // 96 bits (recommended for GCM)
+    private const int TagSize = 16; // 128 bits
+
+    private readonly byte[] _key;
+    private readonly string? _keyId;
+
+    public string Algorithm => "AES-256-GCM";
+
+    /// <summary>
+    /// Creates a new AES-GCM encryptor with the specified key
+    /// </summary>
+    /// <param name="key">The 256-bit encryption key</param>
+    /// <param name="keyId">Optional key identifier for key rotation</param>
+    public AesGcmMessageEncryptor(byte[] key, string? keyId = null)
+    {
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+
+        if (key.Length != KeySize)
+            throw new ArgumentException($"Key must be {KeySize} bytes ({KeySize * 8} bits)", nameof(key));
+
+        _key = new byte[key.Length];
+        Array.Copy(key, _key, key.Length);
+        _keyId = keyId;
+    }
+
+    /// <summary>
+    /// Creates a new AES-GCM encryptor by generating a random key
+    /// </summary>
+    public static AesGcmMessageEncryptor CreateWithRandomKey(string? keyId = null)
+    {
+        var key = new byte[KeySize];
+        using (var rng = RandomNumberGenerator.Create())
+        {
+            rng.GetBytes(key);
+        }
+        return new AesGcmMessageEncryptor(key, keyId);
+    }
+
+    public Task<EncryptedData> EncryptAsync(
+        byte[] plaintext,
+        SecurityContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (plaintext == null)
+            throw new ArgumentNullException(nameof(plaintext));
+
+        try
+        {
+            // Generate a random nonce (IV)
+            var nonce = new byte[NonceSize];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(nonce);
+            }
+
+            var ciphertext = new byte[plaintext.Length];
+            var tag = new byte[TagSize];
+
+#if NETSTANDARD2_0
+            // AesGcm is not available in netstandard2.0
+            throw new PlatformNotSupportedException(
+                "AES-GCM is not available in .NET Standard 2.0. " +
+                "Please target .NET 6.0 or later for AES-GCM support, " +
+                "or use AesCbcHmacMessageEncryptor for .NET Standard 2.0 compatibility.");
+#elif NET8_0_OR_GREATER
+            // .NET 8+ supports tag size in constructor
+            using (var aes = new AesGcm(_key, TagSize))
+            {
+                aes.Encrypt(nonce, plaintext, ciphertext, tag);
+            }
+#else
+            // .NET 6-7 don't support tag size parameter
+            using (var aes = new AesGcm(_key))
+            {
+                aes.Encrypt(nonce, plaintext, ciphertext, tag);
+            }
+#endif
+
+            var encryptedData = new EncryptedData(
+                ciphertext,
+                nonce,
+                Algorithm,
+                tag,
+                _keyId);
+
+            return Task.FromResult(encryptedData);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new EncryptionException("Failed to encrypt message", ex);
+        }
+    }
+
+    public Task<byte[]> DecryptAsync(
+        EncryptedData encryptedData,
+        SecurityContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (encryptedData == null)
+            throw new ArgumentNullException(nameof(encryptedData));
+
+        if (encryptedData.Algorithm != Algorithm)
+            throw new EncryptionException($"Unsupported algorithm: {encryptedData.Algorithm}. Expected: {Algorithm}");
+
+        if (encryptedData.AuthenticationTag == null)
+            throw new EncryptionException("Authentication tag is required for AES-GCM decryption");
+
+        try
+        {
+            var plaintext = new byte[encryptedData.Ciphertext.Length];
+
+#if NETSTANDARD2_0
+            // AesGcm is not available in netstandard2.0
+            throw new PlatformNotSupportedException(
+                "AES-GCM is not available in .NET Standard 2.0. " +
+                "Please target .NET 6.0 or later for AES-GCM support, " +
+                "or use AesCbcHmacMessageEncryptor for .NET Standard 2.0 compatibility.");
+#elif NET8_0_OR_GREATER
+            // .NET 8+ supports tag size in constructor
+            using (var aes = new AesGcm(_key, TagSize))
+            {
+                aes.Decrypt(
+                    encryptedData.InitializationVector,
+                    encryptedData.Ciphertext,
+                    encryptedData.AuthenticationTag,
+                    plaintext);
+            }
+#else
+            // .NET 6-7 don't support tag size parameter
+            using (var aes = new AesGcm(_key))
+            {
+                aes.Decrypt(
+                    encryptedData.InitializationVector,
+                    encryptedData.Ciphertext,
+                    encryptedData.AuthenticationTag,
+                    plaintext);
+            }
+#endif
+
+            return Task.FromResult(plaintext);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new EncryptionException("Failed to decrypt message. The message may have been tampered with.", ex);
+        }
+    }
+}

--- a/src/HeroMessaging.Security/HeroMessaging.Security.csproj
+++ b/src/HeroMessaging.Security/HeroMessaging.Security.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\HeroMessaging.Abstractions\HeroMessaging.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <!-- AesGcm is not available in netstandard2.0, only .NET Core 3.0+ -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
+  </ItemGroup>
+
+</Project>

--- a/tests/HeroMessaging.Security.Tests/HeroMessaging.Security.Tests.csproj
+++ b/tests/HeroMessaging.Security.Tests/HeroMessaging.Security.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\HeroMessaging.Abstractions\HeroMessaging.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\HeroMessaging.Security\HeroMessaging.Security.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/HeroMessaging.Security.Tests/Unit/AesGcmMessageEncryptorTests.cs
+++ b/tests/HeroMessaging.Security.Tests/Unit/AesGcmMessageEncryptorTests.cs
@@ -1,0 +1,273 @@
+using System.Security.Cryptography;
+using HeroMessaging.Abstractions.Security;
+using HeroMessaging.Security.Encryption;
+
+namespace HeroMessaging.Security.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class AesGcmMessageEncryptorTests
+{
+    [Fact]
+    public void Constructor_WithValidKey_CreatesInstance()
+    {
+        // Arrange
+        var key = new byte[32]; // 256 bits
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(key);
+
+        // Act
+        var encryptor = new AesGcmMessageEncryptor(key);
+
+        // Assert
+        Assert.NotNull(encryptor);
+        Assert.Equal("AES-256-GCM", encryptor.Algorithm);
+    }
+
+    [Fact]
+    public void Constructor_WithKeyId_StoresKeyId()
+    {
+        // Arrange
+        var key = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(key);
+        var keyId = "test-key-1";
+
+        // Act
+        var encryptor = new AesGcmMessageEncryptor(key, keyId);
+
+        // Assert
+        Assert.NotNull(encryptor);
+    }
+
+    [Fact]
+    public void Constructor_WithNullKey_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new AesGcmMessageEncryptor(null!));
+        Assert.Equal("key", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidKeySize_ThrowsArgumentException()
+    {
+        // Arrange
+        var invalidKey = new byte[16]; // Only 128 bits, need 256
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() => new AesGcmMessageEncryptor(invalidKey));
+        Assert.Contains("Key must be 32 bytes", exception.Message);
+    }
+
+    [Fact]
+    public void CreateWithRandomKey_GeneratesValidEncryptor()
+    {
+        // Act
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+
+        // Assert
+        Assert.NotNull(encryptor);
+        Assert.Equal("AES-256-GCM", encryptor.Algorithm);
+    }
+
+    [Fact]
+    public void CreateWithRandomKey_WithKeyId_StoresKeyId()
+    {
+        // Arrange
+        var keyId = "generated-key-1";
+
+        // Act
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey(keyId);
+
+        // Assert
+        Assert.NotNull(encryptor);
+    }
+
+#if !NETSTANDARD2_0
+    [Fact]
+    public async Task EncryptAsync_WithValidData_ReturnsEncryptedData()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var plaintext = System.Text.Encoding.UTF8.GetBytes("Hello, World!");
+        var context = new SecurityContext();
+
+        // Act
+        var result = await encryptor.EncryptAsync(plaintext, context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Ciphertext);
+        Assert.NotNull(result.InitializationVector);
+        Assert.NotNull(result.AuthenticationTag);
+        Assert.Equal("AES-256-GCM", result.Algorithm);
+        Assert.Equal(12, result.InitializationVector.Length); // 96 bits
+        Assert.Equal(16, result.AuthenticationTag.Length); // 128 bits
+    }
+
+    [Fact]
+    public async Task EncryptAsync_SameInputTwice_ProducesDifferentCiphertexts()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var plaintext = System.Text.Encoding.UTF8.GetBytes("Test message");
+        var context = new SecurityContext();
+
+        // Act
+        var result1 = await encryptor.EncryptAsync(plaintext, context);
+        var result2 = await encryptor.EncryptAsync(plaintext, context);
+
+        // Assert - Different IVs mean different ciphertexts
+        Assert.NotEqual(result1.InitializationVector, result2.InitializationVector);
+        Assert.NotEqual(result1.Ciphertext, result2.Ciphertext);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithValidEncryptedData_ReturnsOriginalPlaintext()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var originalPlaintext = System.Text.Encoding.UTF8.GetBytes("Secret message");
+        var context = new SecurityContext();
+        var encrypted = await encryptor.EncryptAsync(originalPlaintext, context);
+
+        // Act
+        var decrypted = await encryptor.DecryptAsync(encrypted, context);
+
+        // Assert
+        Assert.Equal(originalPlaintext, decrypted);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithTamperedCiphertext_ThrowsEncryptionException()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var plaintext = System.Text.Encoding.UTF8.GetBytes("Original message");
+        var context = new SecurityContext();
+        var encrypted = await encryptor.EncryptAsync(plaintext, context);
+
+        // Tamper with the ciphertext
+        var tamperedCiphertext = new byte[encrypted.Ciphertext.Length];
+        Array.Copy(encrypted.Ciphertext, tamperedCiphertext, tamperedCiphertext.Length);
+        tamperedCiphertext[0] ^= 0xFF; // Flip bits
+
+        var tamperedData = new EncryptedData(
+            tamperedCiphertext,
+            encrypted.InitializationVector,
+            encrypted.Algorithm,
+            encrypted.AuthenticationTag,
+            encrypted.KeyId);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EncryptionException>(
+            () => encryptor.DecryptAsync(tamperedData, context));
+        Assert.Contains("tampered", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithWrongKey_ThrowsEncryptionException()
+    {
+        // Arrange
+        var encryptor1 = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var encryptor2 = AesGcmMessageEncryptor.CreateWithRandomKey(); // Different key
+        var plaintext = System.Text.Encoding.UTF8.GetBytes("Secret");
+        var context = new SecurityContext();
+        var encrypted = await encryptor1.EncryptAsync(plaintext, context);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<EncryptionException>(
+            () => encryptor2.DecryptAsync(encrypted, context));
+    }
+#endif
+
+    [Fact]
+    public async Task EncryptAsync_WithNullPlaintext_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var context = new SecurityContext();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => encryptor.EncryptAsync(null!, context));
+        Assert.Equal("plaintext", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithNullEncryptedData_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var context = new SecurityContext();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => encryptor.DecryptAsync(null!, context));
+        Assert.Equal("encryptedData", exception.ParamName);
+    }
+
+#if !NETSTANDARD2_0
+    [Fact]
+    public async Task DecryptAsync_WithWrongAlgorithm_ThrowsEncryptionException()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var wrongAlgorithmData = new EncryptedData(
+            new byte[16],
+            new byte[12],
+            "WRONG-ALGORITHM",
+            new byte[16],
+            null);
+        var context = new SecurityContext();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EncryptionException>(
+            () => encryptor.DecryptAsync(wrongAlgorithmData, context));
+        Assert.Contains("Unsupported algorithm", exception.Message);
+    }
+
+    [Fact]
+    public async Task DecryptAsync_WithMissingAuthTag_ThrowsEncryptionException()
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var dataWithoutTag = new EncryptedData(
+            new byte[16],
+            new byte[12],
+            "AES-256-GCM",
+            null, // No auth tag
+            null);
+        var context = new SecurityContext();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EncryptionException>(
+            () => encryptor.DecryptAsync(dataWithoutTag, context));
+        Assert.Contains("Authentication tag is required", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(1024)]
+    public async Task EncryptDecrypt_WithVariousDataSizes_WorksCorrectly(int dataSize)
+    {
+        // Arrange
+        var encryptor = AesGcmMessageEncryptor.CreateWithRandomKey();
+        var plaintext = new byte[dataSize];
+        if (dataSize > 0)
+        {
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plaintext);
+        }
+        var context = new SecurityContext();
+
+        // Act
+        var encrypted = await encryptor.EncryptAsync(plaintext, context);
+        var decrypted = await encryptor.DecryptAsync(encrypted, context);
+
+        // Assert
+        Assert.Equal(plaintext, decrypted);
+    }
+#endif
+}

--- a/tests/HeroMessaging.Security.Tests/Unit/ClaimsAuthenticationProviderTests.cs
+++ b/tests/HeroMessaging.Security.Tests/Unit/ClaimsAuthenticationProviderTests.cs
@@ -1,0 +1,223 @@
+using System.Security.Claims;
+using HeroMessaging.Abstractions.Security;
+using HeroMessaging.Security.Authentication;
+
+namespace HeroMessaging.Security.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class ClaimsAuthenticationProviderTests
+{
+    [Fact]
+    public void Constructor_WithValidScheme_CreatesInstance()
+    {
+        // Act
+        var provider = new ClaimsAuthenticationProvider("ApiKey");
+
+        // Assert
+        Assert.NotNull(provider);
+        Assert.Equal("ApiKey", provider.Scheme);
+    }
+
+    [Fact]
+    public void Constructor_WithDefaultScheme_UsesApiKey()
+    {
+        // Act
+        var provider = new ClaimsAuthenticationProvider();
+
+        // Assert
+        Assert.Equal("ApiKey", provider.Scheme);
+    }
+
+    [Fact]
+    public void RegisterApiKey_WithPrincipal_StoresMapping()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+        var apiKey = "test-key-123";
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "TestUser") }, "ApiKey");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        provider.RegisterApiKey(apiKey, principal);
+
+        // Assert - Will verify in AuthenticateAsync test
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void RegisterApiKey_WithNameAndClaims_CreatesPrincipal()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+        var apiKey = "key-456";
+        var name = "John Doe";
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Role, "admin"),
+            new Claim("department", "Engineering")
+        };
+
+        // Act
+        provider.RegisterApiKey(apiKey, name, claims);
+
+        // Assert - Will verify in AuthenticateAsync test
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithValidApiKey_ReturnsPrincipal()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider("ApiKey");
+        var apiKey = "valid-key";
+        var name = "Alice";
+        provider.RegisterApiKey(apiKey, name, new Claim(ClaimTypes.Role, "user"));
+
+        var credentials = new AuthenticationCredentials("ApiKey", apiKey);
+
+        // Act
+        var principal = await provider.AuthenticateAsync(credentials);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.True(principal.Identity?.IsAuthenticated);
+        Assert.Equal(name, principal.Identity?.Name);
+        Assert.True(principal.IsInRole("user"));
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithInvalidApiKey_ReturnsNull()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider("ApiKey");
+        provider.RegisterApiKey("valid-key", "User1");
+
+        var credentials = new AuthenticationCredentials("ApiKey", "invalid-key");
+
+        // Act
+        var principal = await provider.AuthenticateAsync(credentials);
+
+        // Assert
+        Assert.Null(principal);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithWrongScheme_ReturnsNull()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider("ApiKey");
+        provider.RegisterApiKey("test-key", "User");
+
+        var credentials = new AuthenticationCredentials("Bearer", "test-key");
+
+        // Act
+        var principal = await provider.AuthenticateAsync(credentials);
+
+        // Assert
+        Assert.Null(principal);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithNullCredentials_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => provider.AuthenticateAsync(null!));
+    }
+
+    [Fact]
+    public async Task ValidateTokenAsync_NotImplemented_ReturnsNull()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+
+        // Act
+        var principal = await provider.ValidateTokenAsync("some-token");
+
+        // Assert
+        Assert.Null(principal);
+    }
+
+    [Fact]
+    public void AuthenticationCredentials_FromAuthorizationHeader_ParsesCorrectly()
+    {
+        // Arrange
+        var headerValue = "ApiKey test-key-789";
+
+        // Act
+        var credentials = AuthenticationCredentials.FromAuthorizationHeader(headerValue);
+
+        // Assert
+        Assert.Equal("ApiKey", credentials.Scheme);
+        Assert.Equal("test-key-789", credentials.Value);
+    }
+
+    [Fact]
+    public void AuthenticationCredentials_FromAuthorizationHeader_WithBearer_ParsesCorrectly()
+    {
+        // Arrange
+        var headerValue = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+
+        // Act
+        var credentials = AuthenticationCredentials.FromAuthorizationHeader(headerValue);
+
+        // Assert
+        Assert.Equal("Bearer", credentials.Scheme);
+        Assert.Equal("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", credentials.Value);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithMultipleKeys_ReturnsCorrectPrincipal()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+        provider.RegisterApiKey("key1", "User1", new Claim(ClaimTypes.Role, "user"));
+        provider.RegisterApiKey("key2", "Admin1", new Claim(ClaimTypes.Role, "admin"));
+
+        var credentials1 = new AuthenticationCredentials("ApiKey", "key1");
+        var credentials2 = new AuthenticationCredentials("ApiKey", "key2");
+
+        // Act
+        var principal1 = await provider.AuthenticateAsync(credentials1);
+        var principal2 = await provider.AuthenticateAsync(credentials2);
+
+        // Assert
+        Assert.NotNull(principal1);
+        Assert.Equal("User1", principal1.Identity?.Name);
+        Assert.True(principal1.IsInRole("user"));
+
+        Assert.NotNull(principal2);
+        Assert.Equal("Admin1", principal2.Identity?.Name);
+        Assert.True(principal2.IsInRole("admin"));
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithCustomClaims_IncludesAllClaims()
+    {
+        // Arrange
+        var provider = new ClaimsAuthenticationProvider();
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Role, "manager"),
+            new Claim("department", "Sales"),
+            new Claim("level", "senior"),
+            new Claim("region", "NA")
+        };
+        provider.RegisterApiKey("manager-key", "Bob Manager", claims);
+
+        var credentials = new AuthenticationCredentials("ApiKey", "manager-key");
+
+        // Act
+        var principal = await provider.AuthenticateAsync(credentials);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Contains(principal.Claims, c => c.Type == ClaimTypes.Role && c.Value == "manager");
+        Assert.Contains(principal.Claims, c => c.Type == "department" && c.Value == "Sales");
+        Assert.Contains(principal.Claims, c => c.Type == "level" && c.Value == "senior");
+        Assert.Contains(principal.Claims, c => c.Type == "region" && c.Value == "NA");
+    }
+}

--- a/tests/HeroMessaging.Security.Tests/Unit/HmacSha256MessageSignerTests.cs
+++ b/tests/HeroMessaging.Security.Tests/Unit/HmacSha256MessageSignerTests.cs
@@ -1,0 +1,299 @@
+using System.Security.Cryptography;
+using HeroMessaging.Abstractions.Security;
+using HeroMessaging.Security.Signing;
+
+namespace HeroMessaging.Security.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class HmacSha256MessageSignerTests
+{
+    [Fact]
+    public void Constructor_WithValidKey_CreatesInstance()
+    {
+        // Arrange
+        var key = new byte[32]; // 256 bits
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(key);
+
+        // Act
+        var signer = new HmacSha256MessageSigner(key);
+
+        // Assert
+        Assert.NotNull(signer);
+        Assert.Equal("HMAC-SHA256", signer.Algorithm);
+    }
+
+    [Fact]
+    public void Constructor_WithKeyId_StoresKeyId()
+    {
+        // Arrange
+        var key = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(key);
+        var keyId = "signing-key-1";
+
+        // Act
+        var signer = new HmacSha256MessageSigner(key, keyId);
+
+        // Assert
+        Assert.NotNull(signer);
+    }
+
+    [Fact]
+    public void Constructor_WithNullKey_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new HmacSha256MessageSigner(null!));
+        Assert.Equal("key", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidKeySize_ThrowsArgumentException()
+    {
+        // Arrange
+        var invalidKey = new byte[8]; // Too small
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() => new HmacSha256MessageSigner(invalidKey));
+        Assert.Contains("Key must be at least 128 bits (16 bytes)", exception.Message);
+    }
+
+    [Fact]
+    public void CreateWithRandomKey_GeneratesValidSigner()
+    {
+        // Act
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+
+        // Assert
+        Assert.NotNull(signer);
+        Assert.Equal("HMAC-SHA256", signer.Algorithm);
+    }
+
+    [Fact]
+    public void CreateWithRandomKey_WithKeyId_StoresKeyId()
+    {
+        // Arrange
+        var keyId = "auto-generated-key";
+
+        // Act
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey(keyId);
+
+        // Assert
+        Assert.NotNull(signer);
+    }
+
+    [Fact]
+    public async Task SignAsync_WithValidData_ReturnsSignature()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = System.Text.Encoding.UTF8.GetBytes("Message to sign");
+        var context = new SecurityContext();
+
+        // Act
+        var signature = await signer.SignAsync(data, context);
+
+        // Assert
+        Assert.NotNull(signature);
+        Assert.NotNull(signature.SignatureBytes);
+        Assert.Equal(32, signature.SignatureBytes.Length); // SHA256 produces 256 bits = 32 bytes
+        Assert.Equal("HMAC-SHA256", signature.Algorithm);
+        Assert.True(signature.Timestamp <= DateTimeOffset.UtcNow);
+        Assert.True(signature.Timestamp >= DateTimeOffset.UtcNow.AddSeconds(-5));
+    }
+
+    [Fact]
+    public async Task SignAsync_SameDataTwice_ProducesSameSignature()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = System.Text.Encoding.UTF8.GetBytes("Consistent message");
+        var context = new SecurityContext();
+
+        // Act
+        var signature1 = await signer.SignAsync(data, context);
+        var signature2 = await signer.SignAsync(data, context);
+
+        // Assert - HMAC should be deterministic for same input
+        Assert.Equal(signature1.SignatureBytes, signature2.SignatureBytes);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithValidSignature_ReturnsTrue()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = System.Text.Encoding.UTF8.GetBytes("Verified message");
+        var context = new SecurityContext();
+        var signature = await signer.SignAsync(data, context);
+
+        // Act
+        var isValid = await signer.VerifyAsync(data, signature, context);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithTamperedData_ReturnsFalse()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var originalData = System.Text.Encoding.UTF8.GetBytes("Original message");
+        var tamperedData = System.Text.Encoding.UTF8.GetBytes("Tampered message");
+        var context = new SecurityContext();
+        var signature = await signer.SignAsync(originalData, context);
+
+        // Act
+        var isValid = await signer.VerifyAsync(tamperedData, signature, context);
+
+        // Assert
+        Assert.False(isValid);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithTamperedSignature_ReturnsFalse()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = System.Text.Encoding.UTF8.GetBytes("Message");
+        var context = new SecurityContext();
+        var originalSignature = await signer.SignAsync(data, context);
+
+        // Tamper with signature
+        var tamperedBytes = new byte[originalSignature.SignatureBytes.Length];
+        Array.Copy(originalSignature.SignatureBytes, tamperedBytes, tamperedBytes.Length);
+        tamperedBytes[0] ^= 0xFF; // Flip bits
+
+        var tamperedSignature = new MessageSignature(
+            tamperedBytes,
+            originalSignature.Algorithm,
+            originalSignature.KeyId,
+            originalSignature.Timestamp);
+
+        // Act
+        var isValid = await signer.VerifyAsync(data, tamperedSignature, context);
+
+        // Assert
+        Assert.False(isValid);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithWrongKey_ReturnsFalse()
+    {
+        // Arrange
+        var signer1 = HmacSha256MessageSigner.CreateWithRandomKey();
+        var signer2 = HmacSha256MessageSigner.CreateWithRandomKey(); // Different key
+        var data = System.Text.Encoding.UTF8.GetBytes("Secret data");
+        var context = new SecurityContext();
+        var signature = await signer1.SignAsync(data, context);
+
+        // Act
+        var isValid = await signer2.VerifyAsync(data, signature, context);
+
+        // Assert
+        Assert.False(isValid);
+    }
+
+    [Fact]
+    public async Task SignAsync_WithNullData_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var context = new SecurityContext();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => signer.SignAsync(null!, context));
+        Assert.Equal("data", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithNullData_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var context = new SecurityContext();
+        var data = System.Text.Encoding.UTF8.GetBytes("Test");
+        var signature = await signer.SignAsync(data, context);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => signer.VerifyAsync(null!, signature, context));
+        Assert.Equal("data", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithNullSignature_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var context = new SecurityContext();
+        var data = System.Text.Encoding.UTF8.GetBytes("Test");
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => signer.VerifyAsync(data, null!, context));
+        Assert.Equal("signature", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(1024)]
+    [InlineData(65536)]
+    public async Task SignVerify_WithVariousDataSizes_WorksCorrectly(int dataSize)
+    {
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = new byte[dataSize];
+        if (dataSize > 0)
+        {
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(data);
+        }
+        var context = new SecurityContext();
+
+        // Act
+        var signature = await signer.SignAsync(data, context);
+        var isValid = await signer.VerifyAsync(data, signature, context);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ConstantTimeComparison_PreventsTimingAttacks()
+    {
+        // This test verifies that comparison time is constant regardless of signature match
+        // In practice, this is hard to test reliably, but we can at least verify behavior
+
+        // Arrange
+        var signer = HmacSha256MessageSigner.CreateWithRandomKey();
+        var data = System.Text.Encoding.UTF8.GetBytes("Timing test data");
+        var context = new SecurityContext();
+        var validSignature = await signer.SignAsync(data, context);
+
+        // Create signatures that differ at different positions
+        var differentAtStart = new byte[validSignature.SignatureBytes.Length];
+        Array.Copy(validSignature.SignatureBytes, differentAtStart, differentAtStart.Length);
+        differentAtStart[0] ^= 0xFF;
+
+        var differentAtEnd = new byte[validSignature.SignatureBytes.Length];
+        Array.Copy(validSignature.SignatureBytes, differentAtEnd, differentAtEnd.Length);
+        differentAtEnd[^1] ^= 0xFF;
+
+        var sigStart = new MessageSignature(differentAtStart, validSignature.Algorithm, validSignature.KeyId, validSignature.Timestamp);
+        var sigEnd = new MessageSignature(differentAtEnd, validSignature.Algorithm, validSignature.KeyId, validSignature.Timestamp);
+
+        // Act
+        var resultStart = await signer.VerifyAsync(data, sigStart, context);
+        var resultEnd = await signer.VerifyAsync(data, sigEnd, context);
+
+        // Assert - Both should be false (constant-time comparison)
+        Assert.False(resultStart);
+        Assert.False(resultEnd);
+    }
+}

--- a/tests/HeroMessaging.Security.Tests/Unit/PolicyAuthorizationProviderTests.cs
+++ b/tests/HeroMessaging.Security.Tests/Unit/PolicyAuthorizationProviderTests.cs
@@ -1,0 +1,484 @@
+using System.Security.Claims;
+using HeroMessaging.Abstractions.Security;
+using HeroMessaging.Security.Authorization;
+
+namespace HeroMessaging.Security.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class PolicyAuthorizationProviderTests
+{
+    [Fact]
+    public void Constructor_WithDefaultSettings_RequiresAuthentication()
+    {
+        // Act
+        var provider = new PolicyAuthorizationProvider();
+
+        // Assert
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void Constructor_WithRequireAuthFalse_AllowsAnonymous()
+    {
+        // Act
+        var provider = new PolicyAuthorizationProvider(requireAuthenticatedUser: false);
+
+        // Assert
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void AddPolicy_WithValidPolicy_StoresPolicy()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var policy = new AuthorizationPolicy("test-policy");
+
+        // Act
+        provider.AddPolicy("test-policy", policy);
+
+        // Assert - Will verify through authorization
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void AddPolicy_WithNullName_ThrowsArgumentException()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var policy = new AuthorizationPolicy("test");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => provider.AddPolicy("", policy));
+    }
+
+    [Fact]
+    public void AddPolicy_WithNullPolicy_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => provider.AddPolicy("test", null!));
+    }
+
+    [Fact]
+    public void RequireRole_AddsRolePolicy()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+
+        // Act
+        provider.RequireRole("OrderCommand", MessageOperations.Send, "admin", "manager");
+
+        // Assert - Will verify through authorization
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void RequireClaim_AddsClaimPolicy()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+
+        // Act
+        provider.RequireClaim("PaymentCommand", MessageOperations.Handle, "permission", "process-payments");
+
+        // Assert - Will verify through authorization
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void AllowAnonymous_AddsAnonymousPolicy()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+
+        // Act
+        provider.AllowAnonymous("PublicQuery", MessageOperations.Handle);
+
+        // Assert - Will verify through authorization
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithoutPolicyAndRequireAuth_RequiresAuthentication()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider(requireAuthenticatedUser: true);
+        var unauthenticatedPrincipal = new ClaimsPrincipal();
+
+        // Act
+        var result = await provider.AuthorizeAsync(unauthenticatedPrincipal, "AnyMessage", MessageOperations.Send);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains("Authentication required", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithoutPolicyAndNoRequireAuth_Succeeds()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider(requireAuthenticatedUser: false);
+        var unauthenticatedPrincipal = new ClaimsPrincipal();
+
+        // Act
+        var result = await provider.AuthorizeAsync(unauthenticatedPrincipal, "AnyMessage", MessageOperations.Send);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithRolePolicy_AuthorizedRoleSucceeds()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        provider.RequireRole("OrderCommand", MessageOperations.Send, "admin", "manager");
+
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = await provider.AuthorizeAsync(principal, "OrderCommand", MessageOperations.Send);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithRolePolicy_UnauthorizedRoleFails()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        provider.RequireRole("OrderCommand", MessageOperations.Send, "admin");
+
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "user") }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = await provider.AuthorizeAsync(principal, "OrderCommand", MessageOperations.Send);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains("admin", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithClaimPolicy_ValidClaimSucceeds()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        provider.RequireClaim("PaymentCommand", MessageOperations.Handle, "permission", "process-payments");
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("permission", "process-payments")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = await provider.AuthorizeAsync(principal, "PaymentCommand", MessageOperations.Handle);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithClaimPolicy_InvalidClaimFails()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        provider.RequireClaim("PaymentCommand", MessageOperations.Handle, "permission", "process-payments");
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("permission", "view-only")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = await provider.AuthorizeAsync(principal, "PaymentCommand", MessageOperations.Handle);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains("permission", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithAnonymousPolicy_UnauthenticatedSucceeds()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider(requireAuthenticatedUser: true);
+        provider.AllowAnonymous("PublicQuery", MessageOperations.Handle);
+
+        var unauthenticatedPrincipal = new ClaimsPrincipal();
+
+        // Act
+        var result = await provider.AuthorizeAsync(unauthenticatedPrincipal, "PublicQuery", MessageOperations.Handle);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithWildcardPolicy_MatchesAllMessageTypes()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        provider.RequireRole("*", MessageOperations.Send, "sender");
+
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "sender") }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act - Should match any message type
+        var result1 = await provider.AuthorizeAsync(principal, "OrderCommand", MessageOperations.Send);
+        var result2 = await provider.AuthorizeAsync(principal, "PaymentCommand", MessageOperations.Send);
+
+        // Assert
+        Assert.True(result1.Succeeded);
+        Assert.True(result2.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithNullMessageType_ThrowsArgumentException()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var principal = new ClaimsPrincipal();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.AuthorizeAsync(principal, null!, MessageOperations.Send));
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WithNullOperation_ThrowsArgumentException()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var principal = new ClaimsPrincipal();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.AuthorizeAsync(principal, "Message", null!));
+    }
+
+    [Fact]
+    public async Task HasPermissionAsync_WithValidPermission_ReturnsTrue()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("permission", "delete-orders")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var hasPermission = await provider.HasPermissionAsync(principal, "delete-orders");
+
+        // Assert
+        Assert.True(hasPermission);
+    }
+
+    [Fact]
+    public async Task HasPermissionAsync_WithoutPermission_ReturnsFalse()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("permission", "view-orders")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var hasPermission = await provider.HasPermissionAsync(principal, "delete-orders");
+
+        // Assert
+        Assert.False(hasPermission);
+    }
+
+    [Fact]
+    public async Task HasPermissionAsync_WithNullPrincipal_ReturnsFalse()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+
+        // Act
+        var hasPermission = await provider.HasPermissionAsync(null!, "any-permission");
+
+        // Assert
+        Assert.False(hasPermission);
+    }
+
+    [Fact]
+    public async Task HasPermissionAsync_WithNullPermission_ThrowsArgumentException()
+    {
+        // Arrange
+        var provider = new PolicyAuthorizationProvider();
+        var principal = new ClaimsPrincipal();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.HasPermissionAsync(principal, null!));
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_RequireAuthenticatedUser_SetsFlag()
+    {
+        // Arrange & Act
+        var policy = new AuthorizationPolicy("test")
+            .RequireAuthenticatedUser();
+
+        // Assert
+        Assert.NotNull(policy);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_AllowAnonymous_SetsFlag()
+    {
+        // Arrange & Act
+        var policy = new AuthorizationPolicy("test")
+            .AllowAnonymous();
+
+        // Assert
+        Assert.NotNull(policy);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_RequireRole_WithNoRoles_ThrowsArgumentException()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => policy.RequireRole());
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_RequireClaim_WithNullType_ThrowsArgumentException()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => policy.RequireClaim(null!));
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_RequireAssertion_WithNullFunc_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => policy.RequireAssertion(null!));
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_Evaluate_WithCustomAssertion_ExecutesAssertion()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test")
+            .RequireAuthenticatedUser()
+            .RequireAssertion(p => p.HasClaim("custom", "value"));
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("custom", "value")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = policy.Evaluate(principal);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_Evaluate_WithFailingAssertion_ReturnsFailed()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test")
+            .RequireAuthenticatedUser()
+            .RequireAssertion(p => false); // Always fails
+
+        var identity = new ClaimsIdentity(Array.Empty<Claim>(), "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = policy.Evaluate(principal);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains("Custom authorization requirement failed", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_Evaluate_WithExceptionInAssertion_ReturnsFailed()
+    {
+        // Arrange
+        var policy = new AuthorizationPolicy("test")
+            .RequireAuthenticatedUser()
+            .RequireAssertion(p => throw new InvalidOperationException("Test error"));
+
+        var identity = new ClaimsIdentity(Array.Empty<Claim>(), "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = policy.Evaluate(principal);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains("exception", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_Name_ReturnsCorrectName()
+    {
+        // Arrange
+        var policyName = "my-policy";
+
+        // Act
+        var policy = new AuthorizationPolicy(policyName);
+
+        // Assert
+        Assert.Equal(policyName, policy.Name);
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_Constructor_WithNullName_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AuthorizationPolicy(null!));
+    }
+
+    [Fact]
+    public void AuthorizationPolicy_FluentChaining_WorksCorrectly()
+    {
+        // Arrange & Act
+        var policy = new AuthorizationPolicy("complex-policy")
+            .RequireAuthenticatedUser()
+            .RequireRole("admin", "manager")
+            .RequireClaim("department", "IT", "Engineering")
+            .RequireAssertion(p => p.Identity?.Name?.StartsWith("dev-") == true);
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, "dev-alice"),
+            new Claim(ClaimTypes.Role, "admin"),
+            new Claim("department", "Engineering")
+        }, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var result = policy.Evaluate(principal);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+}


### PR DESCRIPTION
…CM encryption

- Created HeroMessaging.Security project with support for multiple target frameworks.
- Implemented HmacSha256MessageSigner for HMAC-SHA256 message signing.
- Added AesGcmMessageEncryptor for AES-GCM encryption.
- Developed unit tests for HmacSha256MessageSigner and AesGcmMessageEncryptor.
- Introduced ClaimsAuthenticationProvider for API key-based authentication.
- Implemented PolicyAuthorizationProvider for role and claim-based authorization.
- Added comprehensive unit tests for authorization policies and claims.