### PR TITLE
Fix integration test compilation errors and CI configuration

### DIFF
--- a/HeroMessaging.slnx
+++ b/HeroMessaging.slnx
@@ -31,5 +31,9 @@
     <Project Path="tests/HeroMessaging.Storage.PostgreSql.Tests/HeroMessaging.Storage.PostgreSql.Tests.csproj" />
     <Project Path="tests/HeroMessaging.Storage.SqlServer.Tests/HeroMessaging.Storage.SqlServer.Tests.csproj" />
     <Project Path="tests/HeroMessaging.Tests/HeroMessaging.Tests.csproj" />
+    <Project Path="tests/HeroMessaging.Tests.Shared/HeroMessaging.Tests.Shared.csproj" />
+    <Project Path="tests/HeroMessaging.Observability.OpenTelemetry.Tests/HeroMessaging.Observability.OpenTelemetry.Tests.csproj" />
+    <Project Path="tests/HeroMessaging.RingBuffer.Tests/HeroMessaging.RingBuffer.Tests.csproj" />
+    <Project Path="tests/HeroMessaging.Transport.RabbitMQ.Tests/HeroMessaging.Transport.RabbitMQ.Tests.csproj" />
   </Folder>
 </Solution>

--- a/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Integration/TransportInstrumentationIntegrationTests.cs
+++ b/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Integration/TransportInstrumentationIntegrationTests.cs
@@ -52,7 +52,7 @@ public class TransportInstrumentationIntegrationTests : IDisposable
             {
                 _longMeasurements[instrument.Name] = new List<Measurement<long>>();
             }
-            _longMeasurements[instrument.Name].Add(measurement);
+            _longMeasurements[instrument.Name].Add(new Measurement<long>(measurement));
         });
 
         _meterListener.SetMeasurementEventCallback<double>((instrument, measurement, tags, state) =>
@@ -61,7 +61,7 @@ public class TransportInstrumentationIntegrationTests : IDisposable
             {
                 _doubleMeasurements[instrument.Name] = new List<Measurement<double>>();
             }
-            _doubleMeasurements[instrument.Name].Add(measurement);
+            _doubleMeasurements[instrument.Name].Add(new Measurement<double>(measurement));
         });
 
         _meterListener.Start();

--- a/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/HeroMessagingInstrumentationTests.cs
+++ b/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/HeroMessagingInstrumentationTests.cs
@@ -53,7 +53,7 @@ public class HeroMessagingInstrumentationTests : IDisposable
             {
                 _longMeasurements[instrument.Name] = new List<Measurement<long>>();
             }
-            _longMeasurements[instrument.Name].Add(measurement);
+            _longMeasurements[instrument.Name].Add(new Measurement<long>(measurement));
         });
 
         _meterListener.SetMeasurementEventCallback<double>((instrument, measurement, tags, state) =>
@@ -62,7 +62,7 @@ public class HeroMessagingInstrumentationTests : IDisposable
             {
                 _doubleMeasurements[instrument.Name] = new List<Measurement<double>>();
             }
-            _doubleMeasurements[instrument.Name].Add(measurement);
+            _doubleMeasurements[instrument.Name].Add(new Measurement<double>(measurement));
         });
 
         _meterListener.SetMeasurementEventCallback<int>((instrument, measurement, tags, state) =>
@@ -71,7 +71,7 @@ public class HeroMessagingInstrumentationTests : IDisposable
             {
                 _intMeasurements[instrument.Name] = new List<Measurement<int>>();
             }
-            _intMeasurements[instrument.Name].Add(measurement);
+            _intMeasurements[instrument.Name].Add(new Measurement<int>(measurement));
         });
 
         _meterListener.Start();

--- a/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/OpenTelemetryTransportInstrumentationTests.cs
+++ b/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/OpenTelemetryTransportInstrumentationTests.cs
@@ -91,19 +91,18 @@ public class OpenTelemetryTransportInstrumentationTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void StartSendActivity_WithNullEnvelope_ReturnsNullOrThrows()
+    public void StartSendActivity_WithDefaultEnvelope_ReturnsActivityOrNull()
     {
         // Arrange
         var instrumentation = OpenTelemetryTransportInstrumentation.Instance;
 
         // Act & Assert
-        // This might throw ArgumentNullException or return null depending on implementation
-        // We test that it behaves consistently
+        // TransportEnvelope is a struct - test with default value
         var exception = Record.Exception(() =>
-            instrumentation.StartSendActivity(null!, "queue", "transport"));
+            instrumentation.StartSendActivity(default, "queue", "transport"));
 
-        // Either it throws or returns null - both are acceptable
-        Assert.True(exception is ArgumentNullException || exception == null);
+        // Should not throw for default struct value
+        Assert.Null(exception);
     }
 
     #endregion

--- a/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/ServiceCollectionExtensionsTests.cs
+++ b/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/ServiceCollectionExtensionsTests.cs
@@ -25,7 +25,7 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry();
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)null);
 
         // Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -44,7 +44,7 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        var result = mockBuilder.Object.AddOpenTelemetry(configure: null);
+        var result = mockBuilder.Object.AddOpenTelemetry(configure: (Action<OpenTelemetryInstrumentationOptions>?)null);
 
         // Assert
         Assert.NotNull(result);
@@ -64,10 +64,10 @@ public class ServiceCollectionExtensionsTests
         var customServiceName = "CustomService";
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry(options =>
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)(options =>
         {
             options.ServiceName = customServiceName;
-        });
+        }));
 
         // Assert - Options are applied during configuration
         // We verify the registration completed successfully
@@ -86,10 +86,10 @@ public class ServiceCollectionExtensionsTests
 
         // Act
         var exception = Record.Exception(() =>
-            mockBuilder.Object.AddOpenTelemetry(options =>
+            mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)(options =>
             {
                 options.EnableTracing = false;
-            }));
+            })));
 
         // Assert
         Assert.Null(exception);
@@ -106,10 +106,10 @@ public class ServiceCollectionExtensionsTests
 
         // Act
         var exception = Record.Exception(() =>
-            mockBuilder.Object.AddOpenTelemetry(options =>
+            mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)(options =>
             {
                 options.EnableMetrics = false;
-            }));
+            })));
 
         // Assert
         Assert.Null(exception);
@@ -125,11 +125,11 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry(options =>
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)(options =>
         {
             options.EnableTracing = false;
             options.EnableMetrics = false;
-        });
+        }));
 
         // Assert - Transport instrumentation should still be registered
         var serviceProvider = services.BuildServiceProvider();
@@ -147,7 +147,7 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        var result = mockBuilder.Object.AddOpenTelemetry();
+        var result = mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)null);
 
         // Assert
         Assert.Same(mockBuilder.Object, result);
@@ -158,7 +158,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_DefaultValues_AreCorrect()
     {
         // Arrange & Act
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Assert
         Assert.Equal("HeroMessaging", options.ServiceName);
@@ -175,7 +175,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_CanModifyProperties()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Act
         options.ServiceName = "CustomService";
@@ -197,7 +197,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_ConfigureTracing_AddsConfiguration()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
         var configCalled = false;
         Action<TracerProviderBuilder> tracingConfig = builder => { configCalled = true; };
 
@@ -215,7 +215,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_ConfigureMetrics_AddsConfiguration()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
         var configCalled = false;
         Action<MeterProviderBuilder> metricsConfig = builder => { configCalled = true; };
 
@@ -233,7 +233,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_ConfigureTracing_SupportsChaining()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
         Action<TracerProviderBuilder> config1 = builder => { };
         Action<TracerProviderBuilder> config2 = builder => { };
 
@@ -252,7 +252,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_ConfigureMetrics_SupportsChaining()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
         Action<MeterProviderBuilder> config1 = builder => { };
         Action<MeterProviderBuilder> config2 = builder => { };
 
@@ -271,7 +271,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_CombinedConfiguration_WorksTogether()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
         Action<TracerProviderBuilder> tracingConfig = builder => { };
         Action<MeterProviderBuilder> metricsConfig = builder => { };
 
@@ -294,12 +294,12 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry(options =>
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)(options =>
         {
             options.ServiceName = "TestService";
             options.ServiceNamespace = "TestNamespace";
             options.ServiceVersion = "1.2.3";
-        });
+        }));
 
         // Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -316,7 +316,7 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry();
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)null);
 
         // Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -338,8 +338,8 @@ public class ServiceCollectionExtensionsTests
         mockBuilder.Setup(b => b.Build()).Returns(services);
 
         // Act
-        mockBuilder.Object.AddOpenTelemetry();
-        mockBuilder.Object.AddOpenTelemetry(); // Second call
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)null);
+        mockBuilder.Object.AddOpenTelemetry((Action<OpenTelemetryInstrumentationOptions>?)null); // Second call
 
         // Assert
         var serviceProvider = services.BuildServiceProvider();
@@ -354,7 +354,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_TracingConfigurationsProperty_IsNotNull()
     {
         // Arrange & Act
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Assert
         Assert.NotNull(options.TracingConfigurations);
@@ -365,7 +365,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_MetricsConfigurationsProperty_IsNotNull()
     {
         // Arrange & Act
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Assert
         Assert.NotNull(options.MetricsConfigurations);
@@ -376,7 +376,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_WithNullServiceName_AllowsNull()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Act
         options.ServiceName = null!;
@@ -390,7 +390,7 @@ public class ServiceCollectionExtensionsTests
     public void OpenTelemetryOptions_WithEmptyServiceName_AllowsEmpty()
     {
         // Arrange
-        var options = new OpenTelemetryOptions();
+        var options = new OpenTelemetryInstrumentationOptions();
 
         // Act
         options.ServiceName = string.Empty;

--- a/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/TransportInstrumentationTests.cs
+++ b/tests/HeroMessaging.Observability.OpenTelemetry.Tests/Unit/TransportInstrumentationTests.cs
@@ -47,7 +47,7 @@ public class TransportInstrumentationTests : IDisposable
             {
                 _longMeasurements[instrument.Name] = new List<Measurement<long>>();
             }
-            _longMeasurements[instrument.Name].Add(measurement);
+            _longMeasurements[instrument.Name].Add(new Measurement<long>(measurement));
         });
 
         _meterListener.SetMeasurementEventCallback<double>((instrument, measurement, tags, state) =>
@@ -56,7 +56,7 @@ public class TransportInstrumentationTests : IDisposable
             {
                 _doubleMeasurements[instrument.Name] = new List<Measurement<double>>();
             }
-            _doubleMeasurements[instrument.Name].Add(measurement);
+            _doubleMeasurements[instrument.Name].Add(new Measurement<double>(measurement));
         });
 
         _meterListener.Start();

--- a/tests/HeroMessaging.RingBuffer.Tests/Unit/Sequences/SequenceTests.cs
+++ b/tests/HeroMessaging.RingBuffer.Tests/Unit/Sequences/SequenceTests.cs
@@ -10,7 +10,7 @@ public class SequenceTests
     public void Constructor_DefaultValue_SetsToNegativeOne()
     {
         // Arrange & Act
-        var sequence = new Sequence();
+        var sequence = new Sequence(-1);
 
         // Assert
         Assert.Equal(-1, sequence.Value);
@@ -33,7 +33,7 @@ public class SequenceTests
     public void Value_SetAndGet_ReturnsCorrectValue()
     {
         // Arrange
-        var sequence = new Sequence();
+        var sequence = new Sequence(-1);
         const long expectedValue = 100;
 
         // Act
@@ -62,7 +62,7 @@ public class SequenceTests
     public void Value_NegativeValues_HandledCorrectly()
     {
         // Arrange
-        var sequence = new Sequence();
+        var sequence = new Sequence(-1);
 
         // Act
         sequence.Value = -100;
@@ -75,7 +75,7 @@ public class SequenceTests
     public void Value_MaxValue_HandledCorrectly()
     {
         // Arrange
-        var sequence = new Sequence();
+        var sequence = new Sequence(-1);
 
         // Act
         sequence.Value = long.MaxValue;
@@ -88,7 +88,7 @@ public class SequenceTests
     public void Value_MinValue_HandledCorrectly()
     {
         // Arrange
-        var sequence = new Sequence();
+        var sequence = new Sequence(-1);
 
         // Act
         sequence.Value = long.MinValue;

--- a/tests/HeroMessaging.Storage.PostgreSql.Tests/Integration/PostgreSqlIntegrationTestBase.cs
+++ b/tests/HeroMessaging.Storage.PostgreSql.Tests/Integration/PostgreSqlIntegrationTestBase.cs
@@ -10,20 +10,33 @@ public abstract class PostgreSqlIntegrationTestBase : IAsyncLifetime
 {
     protected PostgreSqlContainer? Container;
     protected PostgreSqlStorageOptions? Options;
-    protected string ConnectionString => Container?.GetConnectionString() ?? throw new InvalidOperationException("Container not initialized");
+    private string? _connectionString;
+    protected string ConnectionString => _connectionString ?? throw new InvalidOperationException("Test not initialized");
 
     public async ValueTask InitializeAsync()
     {
-        Container = new PostgreSqlBuilder()
-            .WithImage("postgres:17-alpine")
-            .WithPassword("postgres")
-            .Build();
+        // Use environment variable connection string if available (CI environment)
+        var envConnectionString = Environment.GetEnvironmentVariable("PostgreSql__ConnectionString");
+        if (!string.IsNullOrEmpty(envConnectionString))
+        {
+            _connectionString = envConnectionString;
+        }
+        else
+        {
+            // Fall back to Testcontainers for local development
+            Container = new PostgreSqlBuilder()
+                .WithImage("postgres:17-alpine")
+                .WithPassword("postgres")
+                .Build();
 
-        await Container.StartAsync(TestContext.Current.CancellationToken);
+            await Container.StartAsync(TestContext.Current.CancellationToken);
+
+            _connectionString = Container.GetConnectionString();
+        }
 
         Options = new PostgreSqlStorageOptions
         {
-            ConnectionString = Container.GetConnectionString(),
+            ConnectionString = _connectionString,
             Schema = "test",
             AutoCreateTables = true
         };

--- a/tests/HeroMessaging.Storage.PostgreSql.Tests/PostgreSqlIdempotencyStoreFixture.cs
+++ b/tests/HeroMessaging.Storage.PostgreSql.Tests/PostgreSqlIdempotencyStoreFixture.cs
@@ -15,15 +15,24 @@ public sealed class PostgreSqlIdempotencyStoreFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        // Create and start PostgreSQL container once for all tests
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:17-alpine")
-            .WithPassword("postgres")
-            .Build();
+        // Use environment variable connection string if available (CI environment)
+        var envConnectionString = Environment.GetEnvironmentVariable("PostgreSql__ConnectionString");
+        if (!string.IsNullOrEmpty(envConnectionString))
+        {
+            ConnectionString = envConnectionString;
+        }
+        else
+        {
+            // Fall back to Testcontainers for local development
+            _container = new PostgreSqlBuilder()
+                .WithImage("postgres:17-alpine")
+                .WithPassword("postgres")
+                .Build();
 
-        await _container.StartAsync(TestContext.Current.CancellationToken);
+            await _container.StartAsync(TestContext.Current.CancellationToken);
 
-        ConnectionString = _container.GetConnectionString();
+            ConnectionString = _container.GetConnectionString();
+        }
 
         // Initialize database schema
         await InitializeDatabaseSchemaAsync(ConnectionString);

--- a/tests/HeroMessaging.Storage.SqlServer.Tests/Integration/SqlServerIntegrationTestBase.cs
+++ b/tests/HeroMessaging.Storage.SqlServer.Tests/Integration/SqlServerIntegrationTestBase.cs
@@ -10,20 +10,33 @@ public abstract class SqlServerIntegrationTestBase : IAsyncLifetime
 {
     protected MsSqlContainer? Container;
     protected SqlServerStorageOptions? Options;
-    protected string ConnectionString => Container?.GetConnectionString() ?? throw new InvalidOperationException("Container not initialized");
+    private string? _connectionString;
+    protected string ConnectionString => _connectionString ?? throw new InvalidOperationException("Test not initialized");
 
     public async ValueTask InitializeAsync()
     {
-        Container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
-            .WithPassword("YourStrong@Passw0rd")
-            .Build();
+        // Use environment variable connection string if available (CI environment)
+        var envConnectionString = Environment.GetEnvironmentVariable("SqlServer__ConnectionString");
+        if (!string.IsNullOrEmpty(envConnectionString))
+        {
+            _connectionString = envConnectionString;
+        }
+        else
+        {
+            // Fall back to Testcontainers for local development
+            Container = new MsSqlBuilder()
+                .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+                .WithPassword("YourStrong@Passw0rd")
+                .Build();
 
-        await Container.StartAsync(TestContext.Current.CancellationToken);
+            await Container.StartAsync(TestContext.Current.CancellationToken);
+
+            _connectionString = Container.GetConnectionString();
+        }
 
         Options = new SqlServerStorageOptions
         {
-            ConnectionString = Container.GetConnectionString(),
+            ConnectionString = _connectionString,
             Schema = "test",
             AutoCreateTables = true
         };

--- a/tests/HeroMessaging.Storage.SqlServer.Tests/SqlServerIdempotencyStoreFixture.cs
+++ b/tests/HeroMessaging.Storage.SqlServer.Tests/SqlServerIdempotencyStoreFixture.cs
@@ -16,15 +16,24 @@ public sealed class SqlServerIdempotencyStoreFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        // Create and start SQL Server container once for all tests
-        _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
-            .WithPassword("YourStrong@Passw0rd")
-            .Build();
+        // Use environment variable connection string if available (CI environment)
+        var envConnectionString = Environment.GetEnvironmentVariable("SqlServer__ConnectionString");
+        if (!string.IsNullOrEmpty(envConnectionString))
+        {
+            ConnectionString = envConnectionString;
+        }
+        else
+        {
+            // Fall back to Testcontainers for local development
+            _container = new MsSqlBuilder()
+                .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+                .WithPassword("YourStrong@Passw0rd")
+                .Build();
 
-        await _container.StartAsync(TestContext.Current.CancellationToken);
+            await _container.StartAsync(TestContext.Current.CancellationToken);
 
-        ConnectionString = _container.GetConnectionString();
+            ConnectionString = _container.GetConnectionString();
+        }
 
         // Initialize database schema
         await InitializeDatabaseSchemaAsync(ConnectionString);

--- a/tests/HeroMessaging.Tests.Shared/Sagas/OrderSagaFixture.cs
+++ b/tests/HeroMessaging.Tests.Shared/Sagas/OrderSagaFixture.cs
@@ -228,7 +228,7 @@ public static class OrderSagaStateMachine
                     ctx.Instance.FailureReason = ctx.Data.Reason;
 
                     // Compensate previous steps (refund payment)
-                    await ctx.Compensation.CompensateAsync(TestContext.Current.CancellationToken);
+                    await ctx.Compensation.CompensateAsync();
                 })
                 .TransitionTo(Failed);
 
@@ -248,7 +248,7 @@ public static class OrderSagaStateMachine
                     ctx.Instance.FailureReason = ctx.Data.Reason;
 
                     // Compensate all previous steps (release inventory, refund payment)
-                    await ctx.Compensation.CompensateAsync(TestContext.Current.CancellationToken);
+                    await ctx.Compensation.CompensateAsync();
                 })
                 .TransitionTo(Failed);
 
@@ -268,7 +268,7 @@ public static class OrderSagaStateMachine
                 .Then(async ctx =>
                 {
                     ctx.Instance.FailureReason = ctx.Data.Reason;
-                    await ctx.Compensation.CompensateAsync(TestContext.Current.CancellationToken); // Refund payment
+                    await ctx.Compensation.CompensateAsync(); // Refund payment
                 })
                 .TransitionTo(Cancelled)
                 .Finalize();
@@ -278,7 +278,7 @@ public static class OrderSagaStateMachine
                 .Then(async ctx =>
                 {
                     ctx.Instance.FailureReason = ctx.Data.Reason;
-                    await ctx.Compensation.CompensateAsync(TestContext.Current.CancellationToken); // Release inventory, refund payment
+                    await ctx.Compensation.CompensateAsync(); // Release inventory, refund payment
                 })
                 .TransitionTo(Cancelled)
                 .Finalize();

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/HeroMessaging.Transport.RabbitMQ.Tests.csproj
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/HeroMessaging.Transport.RabbitMQ.Tests.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="xunit.v3" Version="3.2.0" />
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqErrorScenarioIntegrationTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqErrorScenarioIntegrationTests.cs
@@ -88,7 +88,7 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(largeContent, receivedBody);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(2, attemptCount); // Message redelivered after failure
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Empty(receivedBody);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -266,7 +266,7 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(100, receivedCount);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -283,9 +283,9 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
             async (envelope, context, ct) => await Task.CompletedTask);
 
         // Act & Assert - should not throw
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
+        await consumer.DisposeAsync();
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -308,7 +308,7 @@ public class RabbitMqErrorScenarioIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(1, health.ActiveConsumers);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
 
         // Check health after cleanup
         var healthAfter = await Transport.GetHealthAsync(TestContext.Current.CancellationToken);

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqIntegrationTestBase.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqIntegrationTestBase.cs
@@ -32,7 +32,7 @@ public abstract class RabbitMqIntegrationTestBase : IAsyncLifetime
             .WithPortBinding(5672, true) // Random host port
             .WithUsername("guest")
             .WithPassword("guest")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(5672))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("rabbitmq-diagnostics check_port_connectivity"))
             .Build();
 
         await _rabbitMqContainer.StartAsync(TestContext.Current.CancellationToken);
@@ -61,13 +61,13 @@ public abstract class RabbitMqIntegrationTestBase : IAsyncLifetime
     {
         if (Transport != null)
         {
-            await Transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await Transport.DisposeAsync();
         }
 
         if (_rabbitMqContainer != null)
         {
             await _rabbitMqContainer.StopAsync(TestContext.Current.CancellationToken);
-            await _rabbitMqContainer.DisposeAsync(TestContext.Current.CancellationToken);
+            await _rabbitMqContainer.DisposeAsync();
         }
     }
 

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqMessageFlowIntegrationTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqMessageFlowIntegrationTests.cs
@@ -56,7 +56,7 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal("Hello RabbitMQ!", System.Text.Encoding.UTF8.GetString(receivedEnvelope.Body.ToArray()));
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(5, receivedMessages.Count);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal("CustomValue", receivedEnvelope.Headers["CustomHeader"].ToString());
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     #endregion
@@ -215,8 +215,8 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.True(queue2Received.Task.IsCompletedSuccessfully);
 
         // Cleanup
-        await consumer1.DisposeAsync(TestContext.Current.CancellationToken);
-        await consumer2.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer1.DisposeAsync();
+        await consumer2.DisposeAsync();
     }
 
     [Fact]
@@ -301,8 +301,8 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Contains("Event occurred", eventsReceived);
 
         // Cleanup
-        await consumer1.DisposeAsync(TestContext.Current.CancellationToken);
-        await consumer2.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer1.DisposeAsync();
+        await consumer2.DisposeAsync();
     }
 
     #endregion
@@ -363,8 +363,8 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(10, consumer1Messages.Count + consumer2Messages.Count);
 
         // Cleanup
-        await consumer1.DisposeAsync(TestContext.Current.CancellationToken);
-        await consumer2.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer1.DisposeAsync();
+        await consumer2.DisposeAsync();
     }
 
     [Fact]
@@ -410,7 +410,7 @@ public class RabbitMqMessageFlowIntegrationTests : RabbitMqIntegrationTestBase
         Assert.Equal(countAfterStop, receivedCount);
 
         // Cleanup
-        await consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await consumer.DisposeAsync();
     }
 
     #endregion

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqTransportInstrumentationIntegrationTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Integration/RabbitMqTransportInstrumentationIntegrationTests.cs
@@ -144,7 +144,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
             await transport.SendAsync(destination, envelope, TestContext.Current.CancellationToken);
 
             // Wait for message to be received
-            var received = await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10, TestContext.Current.CancellationToken));
+            var received = await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(received, "Message should be received");
@@ -189,7 +189,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
         finally
         {
             await transport.DisconnectAsync(TestContext.Current.CancellationToken);
-            await transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await transport.DisposeAsync();
         }
     }
 
@@ -240,7 +240,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
         finally
         {
             await transport.DisconnectAsync(TestContext.Current.CancellationToken);
-            await transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await transport.DisposeAsync();
         }
     }
 
@@ -300,7 +300,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
         finally
         {
             await transport.DisconnectAsync(TestContext.Current.CancellationToken);
-            await transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await transport.DisposeAsync();
         }
     }
 
@@ -398,7 +398,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
             }
 
             // Wait for all messages
-            await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10, TestContext.Current.CancellationToken));
+            await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             // Assert
             var sendActivities = _activities.Where(a => a.OperationName == "HeroMessaging.Transport.Send").ToList();
@@ -423,7 +423,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
         finally
         {
             await transport.DisconnectAsync(TestContext.Current.CancellationToken);
-            await transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await transport.DisposeAsync();
         }
     }
 
@@ -483,7 +483,7 @@ public sealed class RabbitMqTransportInstrumentationIntegrationTests : IDisposab
         finally
         {
             await transport.DisconnectAsync(TestContext.Current.CancellationToken);
-            await transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await transport.DisposeAsync();
         }
     }
 }

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqChannelPoolTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqChannelPoolTests.cs
@@ -52,7 +52,7 @@ public class RabbitMqChannelPoolTests : IAsyncLifetime
     {
         if (_channelPool != null)
         {
-            await _channelPool.DisposeAsync(TestContext.Current.CancellationToken);
+            await _channelPool.DisposeAsync();
         }
     }
 
@@ -228,7 +228,7 @@ public class RabbitMqChannelPoolTests : IAsyncLifetime
     {
         // Arrange
         var channel = await _channelPool!.AcquireChannelAsync();
-        await _channelPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _channelPool.DisposeAsync();
 
         // Act
         _channelPool.ReleaseChannel(channel);
@@ -355,7 +355,7 @@ public class RabbitMqChannelPoolTests : IAsyncLifetime
         _channelPool.ReleaseChannel(channel2);
 
         // Act
-        await _channelPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _channelPool.DisposeAsync();
 
         // Assert
         foreach (var mockChannel in _mockChannels)
@@ -369,8 +369,8 @@ public class RabbitMqChannelPoolTests : IAsyncLifetime
     {
         // Act
         await _channelPool!.DisposeAsync();
-        await _channelPool.DisposeAsync(TestContext.Current.CancellationToken);
-        await _channelPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _channelPool.DisposeAsync();
+        await _channelPool.DisposeAsync();
 
         // Assert - should not throw
     }

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqConnectionPoolTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqConnectionPoolTests.cs
@@ -44,7 +44,7 @@ public class RabbitMqConnectionPoolTests : IAsyncLifetime
     {
         if (_connectionPool != null)
         {
-            await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
+            await _connectionPool.DisposeAsync();
         }
     }
 
@@ -99,7 +99,7 @@ public class RabbitMqConnectionPoolTests : IAsyncLifetime
         _connectionPool = new RabbitMqConnectionPool(_options!, _mockLogger!.Object, TimeProvider.System);
 
         // Act
-        await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _connectionPool.DisposeAsync();
 
         // Assert
         // Should not throw
@@ -114,9 +114,9 @@ public class RabbitMqConnectionPoolTests : IAsyncLifetime
         _connectionPool = new RabbitMqConnectionPool(_options!, _mockLogger!.Object, TimeProvider.System);
 
         // Act
-        await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
-        await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
-        await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _connectionPool.DisposeAsync();
+        await _connectionPool.DisposeAsync();
+        await _connectionPool.DisposeAsync();
 
         // Assert - should not throw
     }
@@ -151,7 +151,7 @@ public class RabbitMqConnectionPoolTests : IAsyncLifetime
     {
         // Arrange
         _connectionPool = new RabbitMqConnectionPool(_options!, _mockLogger!.Object, TimeProvider.System);
-        await _connectionPool.DisposeAsync(TestContext.Current.CancellationToken);
+        await _connectionPool.DisposeAsync();
 
         // Act & Assert
         await Assert.ThrowsAsync<ObjectDisposedException>(async () =>

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqConsumerTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqConsumerTests.cs
@@ -87,7 +87,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler,
             _options,
             _mockTransport.Object,
-            _mockLogger.Object);
+            _mockLogger.Object,
+            TimeProvider.System);
 
         return ValueTask.CompletedTask;
     }
@@ -96,7 +97,7 @@ public class RabbitMqConsumerTests : IAsyncLifetime
     {
         if (_consumer != null)
         {
-            await _consumer.DisposeAsync(TestContext.Current.CancellationToken);
+            await _consumer.DisposeAsync();
         }
     }
 
@@ -124,7 +125,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -142,7 +144,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -157,7 +160,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -172,7 +176,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 null!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     #endregion
@@ -328,7 +333,7 @@ public class RabbitMqConsumerTests : IAsyncLifetime
         await _consumer!.StartAsync();
 
         // Act
-        await _consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await _consumer.DisposeAsync();
 
         // Assert
         Assert.False(_consumer.IsActive);
@@ -436,7 +441,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 null!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -451,7 +457,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 null!,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -466,7 +473,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                null!));
+                null!,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -481,7 +489,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -499,7 +508,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
                 _handler!,
                 _options!,
                 _mockTransport!.Object,
-                _mockLogger!.Object));
+                _mockLogger!.Object,
+                TimeProvider.System));
     }
 
     [Fact]
@@ -513,7 +523,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             _options!,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Assert
         Assert.Equal("custom-id-12345", customConsumer.ConsumerId);
@@ -535,7 +546,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             options,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -556,7 +568,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             _options!,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -577,7 +590,7 @@ public class RabbitMqConsumerTests : IAsyncLifetime
     public async Task StartAsync_WithManualAck_SetAutoAckToFalse()
     {
         // Arrange
-        var options = new ConsumerOptions { ManualAcknowledgment = true };
+        var options = new ConsumerOptions { AutoAcknowledge = false };
         var consumer = new RabbitMqConsumer(
             "manual-ack-consumer",
             _source!,
@@ -585,7 +598,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             options,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -613,7 +627,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             _options!,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -653,7 +668,7 @@ public class RabbitMqConsumerTests : IAsyncLifetime
         var cts = new CancellationTokenSource();
 
         // Act
-        await _consumer.StopAsync(cts.Token, TestContext.Current.CancellationToken);
+        await _consumer.StopAsync(cts.Token);
 
         // Assert
         _mockChannel!.Verify(ch => ch.BasicCancelAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -709,8 +724,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
     {
         // Act & Assert - Should not throw
         await _consumer!.DisposeAsync();
-        await _consumer.DisposeAsync(TestContext.Current.CancellationToken);
-        await _consumer.DisposeAsync(TestContext.Current.CancellationToken);
+        await _consumer.DisposeAsync();
+        await _consumer.DisposeAsync();
     }
 
     [Fact]
@@ -807,7 +822,7 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             ConsumerId = "custom-id",
             StartImmediately = false,
             PrefetchCount = 25,
-            ManualAcknowledgment = true
+            AutoAcknowledge = false
         };
 
         var consumer = new RabbitMqConsumer(
@@ -817,7 +832,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             customOptions,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -879,7 +895,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             _handler!,
             _options!,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Act
         await consumer.StartAsync(TestContext.Current.CancellationToken);
@@ -918,7 +935,8 @@ public class RabbitMqConsumerTests : IAsyncLifetime
             CustomHandler,
             _options!,
             _mockTransport!.Object,
-            _mockLogger!.Object);
+            _mockLogger!.Object,
+            TimeProvider.System);
 
         // Assert
         Assert.NotNull(consumer);

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqTransportExtensionsTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqTransportExtensionsTests.cs
@@ -1,6 +1,6 @@
 using HeroMessaging.Abstractions.Configuration;
 using HeroMessaging.Abstractions.Transport;
-using HeroMessaging.Transport.RabbitMQ.Configuration;
+using HeroMessaging.Transport.RabbitMQ;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;

--- a/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqTransportTests.cs
+++ b/tests/HeroMessaging.Transport.RabbitMQ.Tests/Unit/RabbitMqTransportTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using HeroMessaging.Abstractions.Transport;
 using HeroMessaging.Transport.RabbitMQ;
 using Microsoft.Extensions.Logging;
@@ -45,7 +46,7 @@ public class RabbitMqTransportTests : IAsyncLifetime
     {
         if (_transport != null)
         {
-            await _transport.DisposeAsync(TestContext.Current.CancellationToken);
+            await _transport.DisposeAsync();
         }
     }
 
@@ -280,8 +281,8 @@ public class RabbitMqTransportTests : IAsyncLifetime
     {
         // Act
         await _transport!.DisposeAsync();
-        await _transport.DisposeAsync(TestContext.Current.CancellationToken);
-        await _transport.DisposeAsync(TestContext.Current.CancellationToken);
+        await _transport.DisposeAsync();
+        await _transport.DisposeAsync();
 
         // Assert - should not throw
     }
@@ -387,8 +388,8 @@ public class RabbitMqTransportTests : IAsyncLifetime
 
         // Assert
         Assert.NotNull(capturedArgs);
-        Assert.Equal(TransportState.Disconnected, capturedArgs.OldState);
-        Assert.Equal(TransportState.Connecting, capturedArgs.NewState);
+        Assert.Equal(TransportState.Disconnected, capturedArgs.PreviousState);
+        Assert.Equal(TransportState.Connecting, capturedArgs.CurrentState);
     }
 
     #endregion
@@ -517,12 +518,7 @@ public class RabbitMqTransportTests : IAsyncLifetime
     public async Task ConfigureTopologyAsync_WithEmptyTopology_ThrowsWhenDisconnected()
     {
         // Arrange
-        var topology = new TransportTopology
-        {
-            Exchanges = new List<ExchangeDefinition>(),
-            Queues = new List<QueueDefinition>(),
-            Bindings = new List<BindingDefinition>()
-        };
+        var topology = new TransportTopology();
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -533,15 +529,10 @@ public class RabbitMqTransportTests : IAsyncLifetime
     public async Task ConfigureTopologyAsync_WithMultipleExchanges_ThrowsWhenDisconnected()
     {
         // Arrange
-        var topology = new TransportTopology
-        {
-            Exchanges = new List<ExchangeDefinition>
-            {
-                new ExchangeDefinition { Name = "exchange1", Type = ExchangeType.Direct },
-                new ExchangeDefinition { Name = "exchange2", Type = ExchangeType.Topic },
-                new ExchangeDefinition { Name = "exchange3", Type = ExchangeType.Fanout }
-            }
-        };
+        var topology = new TransportTopology()
+            .AddExchange(new ExchangeDefinition { Name = "exchange1", Type = ExchangeType.Direct })
+            .AddExchange(new ExchangeDefinition { Name = "exchange2", Type = ExchangeType.Topic })
+            .AddExchange(new ExchangeDefinition { Name = "exchange3", Type = ExchangeType.Fanout });
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -552,20 +543,15 @@ public class RabbitMqTransportTests : IAsyncLifetime
     public async Task ConfigureTopologyAsync_WithQueueArguments_ThrowsWhenDisconnected()
     {
         // Arrange
-        var topology = new TransportTopology
-        {
-            Queues = new List<QueueDefinition>
+        var topology = new TransportTopology()
+            .AddQueue(new QueueDefinition
             {
-                new QueueDefinition
-                {
-                    Name = "test-queue",
-                    Durable = true,
-                    MaxLength = 1000,
-                    MessageTtl = TimeSpan.FromHours(1),
-                    MaxPriority = 10
-                }
-            }
-        };
+                Name = "test-queue",
+                Durable = true,
+                MaxLength = 1000,
+                MessageTtl = TimeSpan.FromHours(1),
+                MaxPriority = 10
+            });
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -576,18 +562,13 @@ public class RabbitMqTransportTests : IAsyncLifetime
     public async Task ConfigureTopologyAsync_WithDeadLetterExchange_ThrowsWhenDisconnected()
     {
         // Arrange
-        var topology = new TransportTopology
-        {
-            Queues = new List<QueueDefinition>
+        var topology = new TransportTopology()
+            .AddQueue(new QueueDefinition
             {
-                new QueueDefinition
-                {
-                    Name = "main-queue",
-                    DeadLetterExchange = "dlx",
-                    DeadLetterRoutingKey = "dead-letter"
-                }
-            }
-        };
+                Name = "main-queue",
+                DeadLetterExchange = "dlx",
+                DeadLetterRoutingKey = "dead-letter"
+            });
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -598,21 +579,10 @@ public class RabbitMqTransportTests : IAsyncLifetime
     public async Task ConfigureTopologyAsync_WithComplexBindings_ThrowsWhenDisconnected()
     {
         // Arrange
-        var topology = new TransportTopology
-        {
-            Exchanges = new List<ExchangeDefinition>
-            {
-                new ExchangeDefinition { Name = "orders", Type = ExchangeType.Topic }
-            },
-            Queues = new List<QueueDefinition>
-            {
-                new QueueDefinition { Name = "order-queue" }
-            },
-            Bindings = new List<BindingDefinition>
-            {
-                new BindingDefinition { SourceExchange = "orders", Destination = "order-queue", RoutingKey = "order.#" }
-            }
-        };
+        var topology = new TransportTopology()
+            .AddExchange(new ExchangeDefinition { Name = "orders", Type = ExchangeType.Topic })
+            .AddQueue(new QueueDefinition { Name = "order-queue" })
+            .AddBinding(new BindingDefinition { SourceExchange = "orders", Destination = "order-queue", RoutingKey = "order.#" });
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -689,23 +659,25 @@ public class RabbitMqTransportTests : IAsyncLifetime
     }
 
     [Fact]
-    public void StateChanged_EventIsNullableByDefault()
+    public void StateChanged_CanSubscribeAndUnsubscribe()
     {
-        // Arrange & Act
-        _transport!.StateChanged = null;
+        // Arrange
+        EventHandler<TransportStateChangedEventArgs> handler = (_, _) => { };
 
-        // Assert - Should not throw when event is null
-        Assert.Null(_transport.StateChanged);
+        // Act & Assert - Should not throw
+        _transport!.StateChanged += handler;
+        _transport.StateChanged -= handler;
     }
 
     [Fact]
-    public void Error_EventIsNullableByDefault()
+    public void Error_CanSubscribeAndUnsubscribe()
     {
-        // Arrange & Act
-        _transport!.Error = null;
+        // Arrange
+        EventHandler<TransportErrorEventArgs> handler = (_, _) => { };
 
-        // Assert - Should not throw when event is null
-        Assert.Null(_transport.Error);
+        // Act & Assert - Should not throw
+        _transport!.Error += handler;
+        _transport.Error -= handler;
     }
 
     #endregion


### PR DESCRIPTION
- Add 4 missing test projects to solution file (OpenTelemetry.Tests,
  RingBuffer.Tests, Transport.RabbitMQ.Tests, Tests.Shared)
- Fix xunit.v3 version mismatch in RabbitMQ.Tests (3.2.0 → 3.2.2)
- Fix Sequence constructor calls in RingBuffer.Tests (parameterless
  constructor was removed; use Sequence(-1) instead)
- Fix ambiguous AddOpenTelemetry calls in OpenTelemetry.Tests by
  explicitly casting to Action<OpenTelemetryInstrumentationOptions>
- Fix Measurement<T> type errors in meter listener callbacks
- Fix OpenTelemetryOptions → OpenTelemetryInstrumentationOptions in
  option property tests (ServiceNamespace, ConfigureTracing, etc.)
- Fix TransportEnvelope null test (struct cannot be null; use default)
- Fix DisposeAsync(CancellationToken) → DisposeAsync() across all
  RabbitMQ test files (IAsyncDisposable takes no parameters)
- Fix missing TimeProvider.System argument in RabbitMqConsumer
  constructor calls
- Fix TransportTopology read-only property assignments (use builder
  methods AddQueue/AddExchange/AddBinding)
- Fix TransportStateChangedEventArgs property names (OldState/NewState
  → PreviousState/CurrentState)
- Fix event assignment tests (events use +=/-=, not direct assignment)
- Fix missing namespace in RabbitMqTransportExtensionsTests
- Fix CompensateAsync call in OrderSagaFixture (remove invalid
  CancellationToken argument)
- Add environment variable fallback to database test fixtures for CI
  (PostgreSQL and SQL Server fixtures now check for env vars before
  creating Testcontainers)

https://claude.ai/code/session_01FjNURGhoQso1SXM7aUi14U